### PR TITLE
request.js lazy init

### DIFF
--- a/src/api/request.js
+++ b/src/api/request.js
@@ -7,12 +7,12 @@ import { COMMA_URL_ROOT } from './config';
 
 const request = ConfigRequest();
 
-var initialized = false;
-async function ensureInit() {
-  if (initialized) return;
-
-  await init();
-  initialized = true;
+var initPromise;
+function ensureInit() {
+  if (!initPromise) {
+    initPromise = init();
+  }
+  return initPromise;
 }
 
 async function init() {


### PR DESCRIPTION
fixes a bug I noticed, where annotations API was failing on first auth due to init() called in the `require` chain.

other API calls succeeded, because the timeline worker holds a separate instance only instantiated post-auth. 