### PR TITLE
Improve loop&zoom ux: clearing, collapsing, browser back behavior...

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -32,7 +32,8 @@ export function selectRange (start, end) {
     if (!state.workerState.loop.startTime
       || !state.workerState.loop.duration
       || state.workerState.loop.startTime < start
-      || state.workerState.loop.startTime + state.workerState.loop.duration > end) {
+      || state.workerState.loop.startTime + state.workerState.loop.duration > end
+      || state.workerState.loop.duration < end - start) {
       Timelineworker.selectLoop(start, end - start);
     }
 

--- a/src/components/annotations/entry.js
+++ b/src/components/annotations/entry.js
@@ -171,6 +171,8 @@ class AnnotationEntry extends Component {
           comment: this.state.comment
         });
       }
+
+      Timelineworker.selectLoop(null, null);
     } catch (e) {
       Raven.captureException(e);
       // no error
@@ -294,6 +296,7 @@ class AnnotationEntry extends Component {
             variant='outlined'
             size='small'
             disabled={ this.state.saving }
+            onClick={ this.props.onChange }
           >Cancel</Button>
         </ExpansionPanelActions>
       </ExpansionPanel>

--- a/src/timeline/playback.js
+++ b/src/timeline/playback.js
@@ -15,10 +15,19 @@ module.exports = {
 
 function reducer (state = initialState, action) {
   // console.log(action);
+  var loopOffset = null;
+  if (state.loop && state.loop.startTime !== null) {
+    loopOffset = state.loop.startTime - state.start;
+  }
   switch (action.type) {
     case ACTION_SEEK:
       state.offset = action.offset;
       state.startTime = Date.now();
+      if (loopOffset !== null
+          && (state.offset < loopOffset || state.offset > (loopOffset + state.loop.duration))) {
+        // seek out of loop bounds,
+        state.loop = { startTime: null, duration: null };
+      }
       break;
     case ACTION_PAUSE:
       state.offset = currentOffset(state);
@@ -43,8 +52,8 @@ function reducer (state = initialState, action) {
 
   let offset = state.offset + (Date.now() - state.startTime) * state.playSpeed;
   // normalize over loop
-  if (state.loop && state.loop.startTime) {
-    let loopOffset = state.loop.startTime - state.start;
+  if (state.loop && state.loop.startTime !== null) {
+    loopOffset = state.loop.startTime - state.start;
     // has loop, trap offset within the loop
     if (offset < loopOffset) {
       state.startTime = Date.now();


### PR DESCRIPTION
- Clear loop upon seek outside loop boundaries
- Collapse annotation upon seek outside loop boundaries
- Clear loop upon annotation resolve or cancel
    - Cancel also now collapses the entry
- Selecting an annotation outside zoom window changes zoom state
- Loop will be reset upon selectRange if it is smaller than the new window
    - intended to handle case where browser back returns to larger time window

