### PR TITLE
Planned disengagements in the 'Resolved' tab; add steering disengagements

### DIFF
--- a/src/components/annotations/common.js
+++ b/src/components/annotations/common.js
@@ -1,4 +1,4 @@
 
 export function filterEvent (event) {
-  return event.type === 'disengage';
+  return (event.type === 'disengage' || event.type === 'disengage_steer');
 }

--- a/src/components/annotations/entry.js
+++ b/src/components/annotations/entry.js
@@ -264,6 +264,7 @@ class AnnotationEntry extends Component {
                     Choose one
                   </MenuItem>
                 }
+                { this.isPlanned() && <MenuItem value={ this.props.event.annotation.data.reason }>{ this.props.event.annotation.data.reason }</MenuItem> }
                 <MenuItem value='arbitrary'>Arbitrary or accidental</MenuItem>
                 <MenuItem value='danger'>I needed to take over for safety</MenuItem>
                 <MenuItem value='lanes'>Lane change</MenuItem>
@@ -327,7 +328,16 @@ class AnnotationEntry extends Component {
   }
   getTitle () {
     // this.props.event
-    return 'Disengage event';
+    if (this.isPlanned()) {
+      return 'Planned disengagement';
+    } else if (this.props.event.type === 'disengage_steer') {
+      return 'Steering disengagement';
+    } else if (this.props.event.type === 'disengage') {
+      return 'Disengagement';
+    }
+  }
+  isPlanned () {
+    return (this.props.event.data && this.props.event.annotation && this.props.event.data.is_planned)
   }
 }
 


### PR DESCRIPTION
Let's merge this before the next demo at 10am

example: (see the Resolved tab) http://127.0.0.1:3000/001bc6c2ce4ab3c7/1530818709445/1530821686089