### PR TITLE
Group drive list by date and seperate with subheadings

### DIFF
--- a/src/components/Dashboard/DriveList.js
+++ b/src/components/Dashboard/DriveList.js
@@ -95,7 +95,7 @@ class DriveList extends Component {
         <div className={classes.drives}>
           { Object.entries(drivesGroupedByDate).map(([date, drives]) => (
             <>
-              <DriveListDivider key={date} date={date} small={small} />
+              <DriveListDivider key={date} date={date} />
               { drives.map((drive) => (
                 <DriveListItem key={drive.startTime} drive={drive} windowWidth={windowWidth} />
               ))}

--- a/src/components/Dashboard/DriveList.js
+++ b/src/components/Dashboard/DriveList.js
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import fecha from 'fecha';
 import Obstruction from 'obstruction';
-import { withStyles, Typography, Grid } from '@material-ui/core';
+import { withStyles, Grid, Typography } from '@material-ui/core';
 
 import Colors from '../../colors';
+import DriveListDivider from './DriveListDivider';
 import DriveListItem from './DriveListItem';
 import ResizeHandler from '../ResizeHandler';
 import VisibilityHandler from '../VisibilityHandler';
@@ -26,11 +27,6 @@ const styles = (theme) => ({
     margin: 0,
     padding: 16,
     flex: '1',
-  },
-  dateHeading: {
-    fontSize: '1.5em',
-    fontWeight: 600,
-    padding: '16px 8px',
   },
   zeroState: {
     flex: '0',
@@ -97,11 +93,9 @@ class DriveList extends Component {
         <VisibilityHandler onVisible={ this.onVisible } minInterval={ 60 } />
         { driveList.length === 0 && this.renderZeroRides() }
         <div className={classes.drives}>
-          { Object.entries(drivesGroupedByDate).map(([startDate, drives]) => (
+          { Object.entries(drivesGroupedByDate).map(([date, drives]) => (
             <>
-              <Typography className={ classes.dateHeading }>
-                { startDate }
-              </Typography>
+              <DriveListDivider key={date} date={date} small={small} />
               { drives.map((drive) => (
                 <DriveListItem key={drive.startTime} drive={drive} windowWidth={windowWidth} />
               ))}

--- a/src/components/Dashboard/DriveList.js
+++ b/src/components/Dashboard/DriveList.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import fecha from 'fecha';
 import Obstruction from 'obstruction';
 import { withStyles, Typography, Grid } from '@material-ui/core';
 
@@ -25,6 +26,11 @@ const styles = (theme) => ({
     margin: 0,
     padding: 16,
     flex: '1',
+  },
+  dateHeading: {
+    fontSize: '1.5em',
+    fontWeight: 600,
+    padding: '16px 8px',
   },
   zeroState: {
     flex: '0',
@@ -67,11 +73,23 @@ class DriveList extends Component {
 
   render() {
     const { classes, dongleId } = this.props;
+    const { windowWidth } = this.state;
 
     const driveList = this.props.segments.slice().reverse().map((segment) => ({
       ...segment,
       dongleId: dongleId,
     }));
+
+    const small = windowWidth < 640;
+
+    const drivesGroupedByDate = driveList.reduce((dates, drive) => {
+      const date = fecha.format(new Date(drive.startTime), small ? 'ddd, MMM D' : 'dddd, MMMM D');
+      if (!dates[date]) {
+        dates[date] = [];
+      }
+      dates[date].push(drive);
+      return dates;
+    }, {});
 
     return (
       <div className={ classes.drivesTable }>
@@ -79,8 +97,15 @@ class DriveList extends Component {
         <VisibilityHandler onVisible={ this.onVisible } minInterval={ 60 } />
         { driveList.length === 0 && this.renderZeroRides() }
         <div className={classes.drives}>
-          { driveList.map((drive, i) => (
-            <DriveListItem key={drive.startTime} drive={drive} windowWidth={ this.state.windowWidth } />
+          { Object.entries(drivesGroupedByDate).map(([startDate, drives]) => (
+            <>
+              <Typography className={ classes.dateHeading }>
+                { startDate }
+              </Typography>
+              { drives.map((drive) => (
+                <DriveListItem key={drive.startTime} drive={drive} windowWidth={windowWidth} />
+              ))}
+            </>
           ))}
         </div>
       </div>

--- a/src/components/Dashboard/DriveListDivider.js
+++ b/src/components/Dashboard/DriveListDivider.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react';
+import { withStyles, Typography } from '@material-ui/core';
+
+const styles = (theme) => ({
+  divider: {
+    display: 'flex',
+    flexDirecton: 'row',
+    padding: '8px',
+    alignItems: 'center',
+    textAlign: 'center',
+  },
+  line: {
+    flexGrow: 1,
+    height: '1px',
+    background: '#fff',
+  },
+  heading: {
+    fontWeight: 500,
+    padding: '0 10px',
+  },
+});
+
+class DriveListDivider extends Component {
+  render() {
+    const { classes, date } = this.props;
+
+    return (
+      <div className={ classes.divider }>
+        <div className={ classes.line } />
+        <Typography className={ classes.heading }>
+          { date }
+        </Typography>
+        <div className={ classes.line } />
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles)(DriveListDivider);


### PR DESCRIPTION
It can be confusing with so many drives in the list to find one you want, but I think adding subheadings to group the drives by date would make it nicer to use. The design might not be up to standard but I think this is quite simple :smile: 

![Screenshot from 2022-04-24 00-03-56](https://user-images.githubusercontent.com/4038174/164948900-dea031b1-22e8-47bf-a2a9-90aab2d8f5f0.png)

