### PR TITLE
remove mapbox hyperlink from bottom-left corner of map

### DIFF
--- a/patches/mapbox-gl+1.13.1.patch
+++ b/patches/mapbox-gl+1.13.1.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/mapbox-gl/src/css/mapbox-gl.css b/node_modules/mapbox-gl/src/css/mapbox-gl.css
+index 17e5ed3..2ce1c1e 100644
+--- a/node_modules/mapbox-gl/src/css/mapbox-gl.css
++++ b/node_modules/mapbox-gl/src/css/mapbox-gl.css
+@@ -395,6 +395,7 @@
+ }
+ 
+ a.mapboxgl-ctrl-logo {
++    display: none !important;
+     width: 88px;
+     height: 23px;
+     margin: 0 0 -4px -4px;


### PR DESCRIPTION
Hyperlink doesn't appear on the bottom-left corner of map anymore.

Solution required me to patch the mapbox-gl module in order to prevent module from being changed when npm updated.

Let me know if this solution is fine or if it violates terms of service with mapbox.