### PR TITLE
show user flags in timeline

### DIFF
--- a/src/actions/cached.js
+++ b/src/actions/cached.js
@@ -151,10 +151,6 @@ function parseEvents(route, driveEvents) {
   let currFlag = null;
   for (const ev of driveEvents) {
     if (ev.type === 'state') {
-      if (currFlag && currFlag.end_route_offset_millis > ev.route_offset_millis) {
-        ev.route_offset_millis = currFlag.end_route_offset_millis;
-      }
-
       if (currEngaged !== null && !ev.data.enabled) {
         currEngaged.data.end_route_offset_millis = ev.route_offset_millis;
         currEngaged = null;
@@ -215,44 +211,7 @@ function parseEvents(route, driveEvents) {
           end_route_offset_millis: ev.route_offset_millis + 1e3,
         },
         type: 'flag',
-      }
-
-      // split any current event if it overlaps with flag
-      if (currEngaged && currEngaged.data.end_route_offset_millis > ev.route_offset_millis) {
-        const prev = currEngaged;
-        prev.data.end_route_offset_millis = ev.route_offset_millis;
-        res.push(prev);
-
-        currEngaged = {
-          ...currEngaged,
-          route_offset_millis: currFlag.data.end_route_offset_millis,
-          data: { ...currEngaged.data },
-          type: 'engage',
-        };
-      } else if (currAlert && currAlert.data.end_route_offset_millis > ev.route_offset_millis) {
-        const prev = currAlert;
-        prev.data.end_route_offset_millis = ev.route_offset_millis;
-        res.push(prev);
-
-        currAlert = {
-          ...currAlert,
-          route_offset_millis: currFlag.data.end_route_offset_millis,
-          data: { ...currAlert.data },
-          type: 'alert',
-        };
-      } else if (currOverride && currOverride.data.end_route_offset_millis > ev.route_offset_millis) {
-        const prev = currOverride;
-        prev.data.end_route_offset_millis = ev.route_offset_millis;
-        res.push(prev);
-
-        currOverride = {
-          ...currOverride,
-          route_offset_millis: currFlag.data.end_route_offset_millis,
-          data: { ...currOverride.data },
-          type: 'overriding',
-        };
-      }
-
+      };
       res.push(currFlag);
     }
   }

--- a/src/actions/cached.js
+++ b/src/actions/cached.js
@@ -207,7 +207,7 @@ function parseEvents(route, driveEvents) {
       res.push(ev);
     } else if (ev.type === 'event') {
       res.push(ev);
-    } else if (ev.type === 'flag') {
+    } else if (ev.type === 'user_flag') {
       currFlag = {
         ...ev,
         data: {

--- a/src/actions/cached.js
+++ b/src/actions/cached.js
@@ -208,10 +208,6 @@ function parseEvents(route, driveEvents) {
     } else if (ev.type === 'event') {
       res.push(ev);
     } else if (ev.type === 'user_flag') {
-      if (currFlag && currFlag.data.end_route_offset_millis > ev.route_offset_millis) {
-        ev.route_offset_millis = currFlag.data.end_route_offset_millis;
-      }
-
       currFlag = {
         ...ev,
         data: {

--- a/src/actions/cached.js
+++ b/src/actions/cached.js
@@ -208,6 +208,10 @@ function parseEvents(route, driveEvents) {
     } else if (ev.type === 'event') {
       res.push(ev);
     } else if (ev.type === 'user_flag') {
+      if (currFlag && currFlag.data.end_route_offset_millis > ev.route_offset_millis) {
+        ev.route_offset_millis = currFlag.data.end_route_offset_millis;
+      }
+
       currFlag = {
         ...ev,
         data: {

--- a/src/actions/cached.js
+++ b/src/actions/cached.js
@@ -148,8 +148,13 @@ function parseEvents(route, driveEvents) {
   let currAlert = null;
   let currOverride = null;
   let lastEngage = null;
+  let currFlag = null;
   for (const ev of driveEvents) {
     if (ev.type === 'state') {
+      if (currFlag && currFlag.end_route_offset_millis > ev.route_offset_millis) {
+        ev.route_offset_millis = currFlag.end_route_offset_millis;
+      }
+
       if (currEngaged !== null && !ev.data.enabled) {
         currEngaged.data.end_route_offset_millis = ev.route_offset_millis;
         currEngaged = null;
@@ -202,6 +207,53 @@ function parseEvents(route, driveEvents) {
       res.push(ev);
     } else if (ev.type === 'event') {
       res.push(ev);
+    } else if (ev.type === 'flag') {
+      currFlag = {
+        ...ev,
+        data: {
+          ...ev.data,
+          end_route_offset_millis: ev.route_offset_millis + 1e3,
+        },
+        type: 'flag',
+      }
+
+      // split any current event if it overlaps with flag
+      if (currEngaged && currEngaged.data.end_route_offset_millis > ev.route_offset_millis) {
+        const prev = currEngaged;
+        prev.data.end_route_offset_millis = ev.route_offset_millis;
+        res.push(prev);
+
+        currEngaged = {
+          ...currEngaged,
+          route_offset_millis: currFlag.data.end_route_offset_millis,
+          data: { ...currEngaged.data },
+          type: 'engage',
+        };
+      } else if (currAlert && currAlert.data.end_route_offset_millis > ev.route_offset_millis) {
+        const prev = currAlert;
+        prev.data.end_route_offset_millis = ev.route_offset_millis;
+        res.push(prev);
+
+        currAlert = {
+          ...currAlert,
+          route_offset_millis: currFlag.data.end_route_offset_millis,
+          data: { ...currAlert.data },
+          type: 'alert',
+        };
+      } else if (currOverride && currOverride.data.end_route_offset_millis > ev.route_offset_millis) {
+        const prev = currOverride;
+        prev.data.end_route_offset_millis = ev.route_offset_millis;
+        res.push(prev);
+
+        currOverride = {
+          ...currOverride,
+          route_offset_millis: currFlag.data.end_route_offset_millis,
+          data: { ...currOverride.data },
+          type: 'overriding',
+        };
+      }
+
+      res.push(currFlag);
     }
   }
 

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -63,6 +63,9 @@ const styles = () => ({
       '&.critical': {
         background: theme.palette.states.alertRed,
       },
+    },
+    '&.flag': {
+      background: theme.palette.states.userFlag,
     }
   },
   thumbnails: {

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -66,6 +66,7 @@ const styles = () => ({
     },
     '&.flag': {
       background: theme.palette.states.userFlag,
+      zIndex: 1,
     }
   },
   thumbnails: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -121,7 +121,7 @@ const theme = createMuiTheme({
       engagedGrey: '#919b95',
       alertOrange: Colors.orange50,
       alertRed: Colors.red100,
-      userFlag: Colors.lightGreen900
+      userFlag: Colors.yellow500
     },
     grey: {
       50: Colors.grey50,

--- a/src/theme.js
+++ b/src/theme.js
@@ -121,6 +121,7 @@ const theme = createMuiTheme({
       engagedGrey: '#919b95',
       alertOrange: Colors.orange50,
       alertRed: Colors.red100,
+      userFlag: Colors.lightGreen900
     },
     grey: {
       50: Colors.grey50,


### PR DESCRIPTION
Add styles for user flags in timeline

The UI already makes it easy to support new event types, so once the backend events.json includes user flags they will appear in the timeline without much effort
![Screenshot from 2022-08-22 17-33-07](https://user-images.githubusercontent.com/4038174/186042985-5bccf1d7-d7a9-4c58-91fc-a2fd97237f00.png)

