### PR TITLE
timeline: minimum event width

### DIFF
--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -463,7 +463,7 @@ class Timeline extends Component {
         const style = {
           left: `${(event.route_offset_millis / route.duration) * 100}%`,
           width: `${((event.data.end_route_offset_millis - event.route_offset_millis) / route.duration) * 100}%`,
-          minWidth: '3px',
+          minWidth: '1px',
         };
         const statusCls = event.data.alertStatus ? `${AlertStatusCodes[event.data.alertStatus]}` : '';
         return (

--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -463,6 +463,7 @@ class Timeline extends Component {
         const style = {
           left: `${(event.route_offset_millis / route.duration) * 100}%`,
           width: `${((event.data.end_route_offset_millis - event.route_offset_millis) / route.duration) * 100}%`,
+          minWidth: '3px',
         };
         const statusCls = event.data.alertStatus ? `${AlertStatusCodes[event.data.alertStatus]}` : '';
         return (


### PR DESCRIPTION
This ensures that timeline events are always visible even for long routes