### PR TITLE
Add ability to open location of car in maps from pin tooltip

### DIFF
--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -1028,15 +1028,17 @@ class Navigation extends Component {
             </Marker>
           )}
           { carLocation &&
-            <Marker latitude={ carLocation.location[1] } longitude={ carLocation.location[0] } offsetLeft={ -10 }
-              offsetTop={ -30 } captureDrag={ false } captureClick={ true } captureDoubleClick={ false }>
-              <img className={ classes.pin } src={ pin_car } onMouseEnter={ () => this.toggleCarPinTooltip(true) }
-                onMouseLeave={ () => this.toggleCarPinTooltip(false) } alt="car-location" />
-              <div className={ classes.carPinTooltip } ref={ this.carPinTooltipRef }
-                style={{ ...carPinTooltipStyle, display: 'none' }}>
-                { fecha.format(carLocation.time, 'h:mm a') },<br />{ timeFromNow(carLocation.time) }
-              </div>
-            </Marker>
+            <div onMouseLeave={ () => this.toggleCarPinTooltip(false) } onMouseEnter={ () => this.toggleCarPinTooltip(true) }>
+              <Marker latitude={ carLocation.location[1] } longitude={ carLocation.location[0] } offsetLeft={ -10 }
+                offsetTop={ -30 } captureDrag={ false } captureClick={ true } captureDoubleClick={ false }>
+                <img className={ classes.pin } src={ pin_car } alt="car-location"/>
+                <div className={ classes.carPinTooltip } ref={ this.carPinTooltipRef }
+                  style={{ ...carPinTooltipStyle, display: 'none' }}>
+                  { fecha.format(carLocation.time, 'h:mm a') },<br />{ timeFromNow(carLocation.time) }<br />
+                  <a target='_blank' href={`https://www.google.com/maps/place/${carLocation.location[1]},${carLocation.location[0]}`}>Open in Maps</a>
+                </div>
+              </Marker>
+            </div>
           }
           { carLocation && Boolean(carLocation.accuracy) &&
             <Source type="geojson" data={ this.carLocationCircle(carLocation) }>


### PR DESCRIPTION
There have been a couple times where I've forgotten where I parked my car. Looking at the Connect app map is somewhat helpful, but it'd often be much easier if I could launch Maps to the exact coordinates of the vehicle instead so I can get my bearings.

This PR facilitates this by allowing the user to "Open in Maps" the location of the car from the car pin tooltip.
![image](https://user-images.githubusercontent.com/7613292/187018069-f9a76e11-e945-44b0-90ff-0a6961e5439f.png)
