### PR TITLE
clips: improve upload UX

### DIFF
--- a/src/components/ClipView/ClipList.js
+++ b/src/components/ClipView/ClipList.js
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/react';
 
 import { withStyles, Typography, CircularProgress, Popper, Popover } from '@material-ui/core';
 import LockOutlineIcon from '@material-ui/icons/LockOutline';
-import ShareIcon from '@material-ui/icons/Share';
+import PublicIcon from '@material-ui/icons/Public';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 import { clips as ClipsApi } from '@commaai/comma-api';
@@ -210,7 +210,7 @@ class ClipList extends Component {
             <h6 style={{ ...itemStyle, ...gridStyles[0] }}></h6>
             <h6 style={{ ...itemStyle, ...gridStyles[1] }}>Title</h6>
             <h6 style={{ ...itemStyle, ...gridStyles[2], textAlign: 'center' }}>Date</h6>
-            <h6 style={{ ...itemStyle, ...gridStyles[3] }}></h6>
+            <h6 style={{ ...itemStyle, ...gridStyles[3] }}>Public</h6>
           </div>
         }
         { clips.list && clips.list.map((c) => this.renderClipItem(gridStyles, c)) }
@@ -268,7 +268,7 @@ class ClipList extends Component {
       </p>
       <p style={{ ...itemStyle, ...gridStyles[2] }}>{ timeStr }</p>
       { c.is_public ?
-        <ShareIcon style={{ ...gridStyles[3], fontSize: (windowWidth < 768 ? '1.0rem' : '1.2rem') }}
+        <PublicIcon style={{ ...gridStyles[3], fontSize: (windowWidth < 768 ? '1.0rem' : '1.2rem') }}
           onClick={ (ev) => { ev.persist(); this.shareClip(ev, c); } } /> :
         <LockOutlineIcon style={{ ...gridStyles[3], fontSize: (windowWidth < 768 ? '1.0rem' : '1.2rem') }} />
       }

--- a/src/components/ClipView/ClipUpload.js
+++ b/src/components/ClipView/ClipUpload.js
@@ -430,7 +430,7 @@ class ClipUpload extends Component {
       <UploadQueue open={ this.state.uploadModal } onClose={ () => this.setState({ uploadModal: false }) }
         update={ !hasUploadedAll } store={ this.props.store } device={ device } />
 
-      <div style={{ padding: viewerPadding }}>
+      <div style={{ padding: `0 ${viewerPadding}px ${viewerPadding}px ${viewerPadding}px` }}>
         <typography>This may take some time. You can leave this page and your clip will continue processing.</typography>
       </div>
     </>;

--- a/src/components/ClipView/ClipUpload.js
+++ b/src/components/ClipView/ClipUpload.js
@@ -419,18 +419,20 @@ class ClipUpload extends Component {
         <div style={{ padding: viewerPadding }}>
           <div className={ classes.clipOption }>
             <h4>{ statusTitle }</h4>
-            <typography>Large files can take a while to process. Please be patient!</typography>
             <div className={ classes.clipProgress }>
               <CircularProgress style={{ margin: 12, color: Colors.white }} size={ 24 } />
               { statusProgress !== null && <span>{ statusProgress }%</span> }
             </div>
-            <typography>You can leave this page and come back to view your clips at any time.</typography>
           </div>
         </div>
       }
 
       <UploadQueue open={ this.state.uploadModal } onClose={ () => this.setState({ uploadModal: false }) }
         update={ !hasUploadedAll } store={ this.props.store } device={ device } />
+
+      <div style={{ padding: viewerPadding }}>
+        <typography>This may take some time. You can leave this page and your clip will continue processing.</typography>
+      </div>
     </>;
   }
 

--- a/src/components/ClipView/ClipUpload.js
+++ b/src/components/ClipView/ClipUpload.js
@@ -419,10 +419,12 @@ class ClipUpload extends Component {
         <div style={{ padding: viewerPadding }}>
           <div className={ classes.clipOption }>
             <h4>{ statusTitle }</h4>
-              <div className={ classes.clipProgress }>
-                <CircularProgress style={{ margin: 12, color: Colors.white }} size={ 24 } />
-                { statusProgress !== null && <span>{ statusProgress}%</span> }
-              </div>
+            <typography>Large files can take a while to process. Please be patient!</typography>
+            <div className={ classes.clipProgress }>
+              <CircularProgress style={{ margin: 12, color: Colors.white }} size={ 24 } />
+              { statusProgress !== null && <span>{ statusProgress }%</span> }
+            </div>
+            <typography>You can leave this page and come back to view your clips at any time.</typography>
           </div>
         </div>
       }


### PR DESCRIPTION
Clip upload/export page:
![Screenshot from 2022-09-29 20-15-25](https://user-images.githubusercontent.com/4038174/193182561-5de64465-03e5-48a6-9cbe-def18eeab3ff.png)
![Screenshot from 2022-09-29 20-20-54](https://user-images.githubusercontent.com/4038174/193183272-ec5f51a9-67c6-468b-a0ec-9abef6538c73.png)

Clips list:
Switched share icon to public icon
|New|Old|
|-|-|
|![Screenshot from 2022-09-27 19-32-19](https://user-images.githubusercontent.com/4038174/192674397-bd4ae00a-4653-49d9-88c0-0f3ec5bef09d.png)|![Screenshot from 2022-09-27 19-32-32](https://user-images.githubusercontent.com/4038174/192674411-529239be-bafc-4f02-997f-e34375acd827.png)|

Resolves #261 