### PR TITLE
remove hls.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "private": true,
   "dependencies": {
     "@commaai/comma-api": "^2.6.0",
-    "@commaai/hls.js": "^0.12.7",
     "@commaai/my-comma-auth": "^1.4.1",
     "@craco/craco": "^6.4.3",
     "@mapbox/mapbox-sdk": "^0.13.5",
@@ -102,7 +101,6 @@
   "jest": {
     "moduleNameMapper": {
       "^@commaai/pandajs$": "<rootDir>/node_modules/@commaai/pandajs/lib/index.js",
-      "^@commaai/hls.js$": "<rootDir>/node_modules/@commaai/hls.js/dist/hls.js",
       "^@commaai/(.*comma.*)$": "<rootDir>/node_modules/@commaai/$1/dist/index.js"
     }
   },

--- a/src/components/DriveVideo/index.js
+++ b/src/components/DriveVideo/index.js
@@ -5,15 +5,12 @@ import { withStyles, CircularProgress } from '@material-ui/core';
 import debounce from 'debounce';
 import Obstruction from 'obstruction';
 import ReactPlayer from 'react-player';
-import Hls from '@commaai/hls.js';
 
 import { video as VideoApi } from '@commaai/comma-api';
 
 import Colors from '../../colors';
 import { seek, bufferVideo, currentOffset } from '../../timeline/playback';
 import { updateSegments } from '../../timeline/segments';
-
-window.Hls = Hls;
 
 const styles = () => ({
   hidden: {

--- a/src/components/DriveVideo/index.js
+++ b/src/components/DriveVideo/index.js
@@ -48,7 +48,7 @@ class DriveVideo extends Component {
     super(props);
 
     this.visibleRoute = this.visibleRoute.bind(this);
-    this.isVideoBuffering = this.isVideoBuffering.bind(this);
+    this.onVideoBuffering = this.onVideoBuffering.bind(this);
     this.syncVideo = debounce(this.syncVideo.bind(this), 200);
     this.firstSeek = true;
 
@@ -107,7 +107,7 @@ class DriveVideo extends Component {
     }
   }
 
-  isVideoBuffering() {
+  onVideoBuffering() {
     const videoPlayer = this.videoPlayer.current;
     if (!videoPlayer || !this.visibleRoute() || !videoPlayer.getDuration()) {
       this.props.dispatch(bufferVideo(true));
@@ -148,7 +148,7 @@ class DriveVideo extends Component {
     }
 
     let newPlaybackRate = this.props.desiredPlaySpeed;
-    let desiredVideoTime = this.currentVideoTime();
+    const desiredVideoTime = this.currentVideoTime();
     const curVideoTime = videoPlayer.getCurrentTime();
     const timeDiff = desiredVideoTime - curVideoTime;
     if (Math.abs(timeDiff) <= 0.3) {
@@ -208,7 +208,7 @@ class DriveVideo extends Component {
           width="100%" height="unset" playing={ Boolean(this.visibleRoute()) && Boolean(playSpeed) }
           config={{ hlsOptions: { enableWorker: false, disablePtsDtsCorrectionInMp4Remux: false } }}
           playbackRate={ playSpeed }
-          onBuffer={ () => this.isVideoBuffering() }
+          onBuffer={ () => this.onVideoBuffering() }
           onBufferEnd={ () => this.props.dispatch(bufferVideo(false)) }
           onPlay={ () => this.props.dispatch(bufferVideo(false)) } />
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1241,14 +1241,6 @@
     joi-browser "^13.4.0"
     query-string "^7.0.1"
 
-"@commaai/hls.js@^0.12.7":
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/@commaai/hls.js/-/hls.js-0.12.7.tgz#1f93e0f0b1921bcd889c768df34eb018c25276fb"
-  integrity sha512-jISvZJRCg5nBv+jn9H7UDcdKPGdjyFcGDOJ9GBksOnXZPEwcVbsrH4FCr7fTju68eEH6rd4ydvYh2O1oYTdjPg==
-  dependencies:
-    eventemitter3 "3.1.0"
-    url-toolkit "^2.1.6"
-
 "@commaai/my-comma-auth@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@commaai/my-comma-auth/-/my-comma-auth-1.4.1.tgz#9c45cf18c5c42586c321aa3fb1bd4693a592487e"
@@ -5941,11 +5933,6 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
-
-eventemitter3@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
-  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -13761,11 +13748,6 @@ url-parse@^1.5.10, url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-url-toolkit@^2.1.6:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.2.5.tgz#58406b18e12c58803e14624df5e374f638b0f607"
-  integrity sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg==
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Not sure whether this is still needed - playback still seems to work without this in chrome and firefox. It adds a lot of JS and increases page load times.

possibly related: https://caniuse.com/http-live-streaming 

![Screenshot from 2022-10-27 20-02-30](https://user-images.githubusercontent.com/4038174/198487637-f22861c5-0f01-4afc-8ec7-40453d5e1807.png)
![Screenshot from 2022-10-27 20-02-38](https://user-images.githubusercontent.com/4038174/198487633-362572b6-917d-4b57-bccf-a570cd3383d9.png)
