### PR TITLE
Add route seconds to hover

### DIFF
--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -438,6 +438,19 @@ class Timeline extends Component {
     return null;
   }
 
+  routeSec(offset) {
+    const { routes } = this.props;
+    if (!routes) {
+      return null;
+    }
+
+    const route = routes.find((r) => r.offset <= offset && r.offset + r.duration >= offset);
+    if (route) {
+      return ((offset - route.segment_offsets[0]) / 1000).toFixed(0);
+    }
+    return null;
+  }
+
   renderRoute(route) {
     const { classes, filter } = this.props;
     const { zoom } = this.state;
@@ -562,8 +575,9 @@ class Timeline extends Component {
       if (!Number.isNaN(hoverOffset)) {
         hoverString = fecha.format(filter.start + hoverOffset, 'HH:mm:ss');
         const segNum = this.segmentNum(hoverOffset);
+        const routeSec = this.routeSec(hoverOffset);
         if (segNum !== null) {
-          hoverString = `${segNum}, ${hoverString}`;
+          hoverString = `${segNum}, ${routeSec}s, ${hoverString}`;
         }
       }
     }


### PR DESCRIPTION
Useful with the starting seconds argument of the replay tool in the openpilot repo:

https://github.com/commaai/openpilot/blob/66edb15b8f558ce81b5a57af4e60fc24e1fc489c/tools/replay/main.cc#L26

<img width="521" alt="Screenshot 2022-11-17 at 1 01 16 AM" src="https://user-images.githubusercontent.com/5363/202404090-b8560e9a-70e4-4278-849a-d2affbe2e1b0.png">
