### PR TITLE
fix NGINX config for static files

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,8 +9,30 @@ server {
   gzip_vary on;
 
   root /usr/share/nginx/html;
+
+  location /service-worker.js {
+    add_header Cache-Control 'no-store, no-cache';
+    if_modified_since off;
+    expires off;
+    etag off;
+
+    try_files $uri $uri/ =404;
+  }
+
+  location /static/ {
+    try_files $uri $uri/ =404;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
+  }
+
+  location /404.html {
+    internal;
+  }
+
+  location /50x.html {
+    internal;
   }
 
   error_page  404              /404.html;


### PR DESCRIPTION
serve 404 for missing static files - it is confusing to redirect these to index.html