### PR TITLE
DriveVideo: reset error on playback resume

### DIFF
--- a/src/components/DriveVideo/index.js
+++ b/src/components/DriveVideo/index.js
@@ -51,6 +51,7 @@ class DriveVideo extends Component {
     this.visibleRoute = this.visibleRoute.bind(this);
     this.onVideoBuffering = this.onVideoBuffering.bind(this);
     this.onVideoError = this.onVideoError.bind(this);
+    this.onVideoResume = this.onVideoResume.bind(this);
     this.syncVideo = debounce(this.syncVideo.bind(this), 200);
     this.firstSeek = true;
 
@@ -143,6 +144,12 @@ class DriveVideo extends Component {
       videoError = 'This video segment has not uploaded yet or has been deleted.';
     }
     this.setState({ videoError });
+  }
+
+  onVideoResume() {
+    const { dispatch } = this.props;
+    dispatch(bufferVideo(false));
+    this.setState({ videoError: null });
   }
 
   syncVideo() {
@@ -246,7 +253,7 @@ class DriveVideo extends Component {
           playbackRate={ playSpeed }
           onBuffer={ this.onVideoBuffering }
           onBufferEnd={ () => dispatch(bufferVideo(false)) }
-          onPlay={ () => dispatch(bufferVideo(false)) }
+          onPlay={ this.onVideoResume }
           onError={ this.onVideoError }
         />
       </div>

--- a/src/components/DriveVideo/index.js
+++ b/src/components/DriveVideo/index.js
@@ -131,11 +131,19 @@ class DriveVideo extends Component {
   }
 
   onVideoError(msg, e) {
+    if (msg?.target?.src?.startsWith(window.location.origin) && msg?.target?.src?.endsWith('undefined')) {
+      // TODO: figure out why the src isn't set properly
+      // Sometimes an error will be thrown because we try to play
+      // src: "https://connect.comma.ai/.../undefined"
+      console.warn('Video error with undefined src, ignoring', { msg, e });
+      return;
+    }
+
     const { dispatch } = this.props;
     dispatch(bufferVideo(false));
     if (!e || !e.response) {
+      console.error('Unknown video error', { msg, e });
       this.setState({ videoError: 'Unable to load video' });
-      console.error('Unknown video error', msg, e);
       return;
     }
 


### PR DESCRIPTION
- Reset the error state when playback resumes
- Ignore errors when the video src is set incorrectly (not sure why this happens yet - possible race condition?)