### PR TITLE
clips: higher z-index for clip bounds sliders and position rect in timeline view

### DIFF
--- a/src/components/Timeline/index.js
+++ b/src/components/Timeline/index.js
@@ -147,6 +147,7 @@ const styles = () => ({
     left: 0,
     height: 32,
     width: '100%',
+    zIndex: 3,
   },
   clipView: {
     backgroundColor: Colors.black,
@@ -157,6 +158,7 @@ const styles = () => ({
     justifyContent: 'center',
     cursor: 'pointer',
     touchAction: 'none',
+    zIndex: 3,
   },
   clipDragHandle: {
     backgroundColor: Colors.white,


### PR DESCRIPTION
The clip bounds sliders and position rect on Create Clip view appear below the "bookmarked" segments.(see the picture below). This is fixed by applying new z-index for `clipView` and `clipRulerRemaining`. 

It's 3 so it would be above the gradient too, which has 2.

![Screenshot from 2023-05-09 17-19-09](https://github.com/commaai/connect/assets/20878008/2671c7ea-d21e-4f23-a96f-f377864162bd)
