### PR TITLE
initial fixes for reactmapgl7

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "raf": "^3.4.1",
     "react": "~18.2",
     "react-dom": "~18.2",
-    "react-map-gl": "^5.3.15",
+    "react-map-gl": "^7.0.23",
     "react-measure": "^2.5.2",
     "react-player": "^2.12.0",
     "react-redux": "^5.0.7",
@@ -52,6 +52,7 @@
     "reduce-reducers": "^1.0.4",
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.1",
+    "viewport-mercator-project": "^7.0.4",
     "web-vitals": "^3.3.1"
   },
   "devDependencies": {

--- a/src/components/DriveMap/index.js
+++ b/src/components/DriveMap/index.js
@@ -4,7 +4,7 @@ import Obstruction from 'obstruction';
 import raf from 'raf';
 import { withStyles } from '@material-ui/core/styles';
 
-import ReactMapGL, { LinearInterpolator } from 'react-map-gl';
+import ReactMapGL from 'react-map-gl';
 
 import { MAPBOX_TOKEN } from '../../utils/geocode';
 import { currentOffset } from '../../timeline/playback';
@@ -17,11 +17,6 @@ const styles = {
   mapContainer: {
     height: '100%',
     cursor: 'default !important',
-    '& div': {
-      height: '100% !important',
-      width: '100% !important',
-      minHeight: 300,
-    },
   },
 };
 
@@ -144,8 +139,7 @@ class DriveMap extends Component {
       latitude: pos[1],
     };
     if (this.shouldFlyTo) {
-      viewport.transitionDuration = 200;
-      viewport.transitionInterpolator = new LinearInterpolator();
+      this.initMap.flyTo({ center: [viewport.longitude, viewport.latitude], duration: 200})
       this.shouldFlyTo = false;
     }
 
@@ -307,12 +301,14 @@ class DriveMap extends Component {
         <ReactMapGL
           width="100%"
           height="100%"
-          latitude={viewport.latitude}
-          longitude={viewport.longitude}
-          zoom={viewport.zoom}
+          initialViewState={{
+            longitude: viewport.longitude,
+            latitude: viewport.latitude,
+            zoom: viewport.zoom,
+          }}
           mapStyle={MAP_STYLE}
           maxPitch={0}
-          mapboxApiAccessToken={MAPBOX_TOKEN}
+          mapboxAccessToken={MAPBOX_TOKEN}
           ref={this.initMap}
           onContextMenu={null}
           dragRotate={false}

--- a/src/components/DriveView/Media.js
+++ b/src/components/DriveView/Media.js
@@ -538,7 +538,7 @@ class Media extends Component {
     const mediaContainerStyle = showMapAlways ? { width: '60%' } : { width: '100%' };
     const mapContainerStyle = showMapAlways
       ? { width: '40%', marginBottom: 62, marginTop: 46, paddingLeft: 24 }
-      : { width: '100%' };
+      : { width: '100%', height: 300 };
 
     return (
       <div className={ classes.root }>

--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -1020,7 +1020,7 @@ class Navigation extends Component {
             latitude: viewport.latitude,
             zoom: viewport.zoom,
           }}
-          onLoad={e => this.geolocateControlRef.current && this.geolocateControlRef.current.trigger()}
+          onClick={e => this.geolocateControlRef.current && this.geolocateControlRef.current.trigger()}
           onViewportChange={this.viewportChange}
           onContextMenu={null}
           mapStyle={MAP_STYLE}

--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import Obstruction from 'obstruction';
 import * as Sentry from '@sentry/react';
 import debounce from 'debounce';
-import ReactMapGL, { GeolocateControl, HTMLOverlay, Marker, Source, WebMercatorViewport, Layer } from 'react-map-gl';
+import ReactMapGL, { GeolocateControl, Marker, Source, Layer } from 'react-map-gl';
+import { WebMercatorViewport } from 'viewport-mercator-project';
+import MapOverlay from './mapoverlay';
 import { withStyles, TextField, InputAdornment, Typography, Button, Menu, MenuItem, CircularProgress, Popper }
   from '@material-ui/core';
 import { Search, Clear, Refresh } from '@material-ui/icons';
@@ -305,6 +307,7 @@ class Navigation extends Component {
     this.overlayRef = React.createRef();
     this.carPinTooltipRef = React.createRef();
     this.navigateFakeButtonRef = React.createRef();
+    this.geolocateControlRef = React.createRef();
 
     this.checkWebGLSupport = this.checkWebGLSupport.bind(this);
     this.flyToMarkers = this.flyToMarkers.bind(this);
@@ -1012,24 +1015,25 @@ class Navigation extends Component {
           </div>
           )}
         <ReactMapGL
-          latitude={viewport.latitude}
-          longitude={viewport.longitude}
-          zoom={viewport.zoom}
-          bearing={viewport.bearing}
-          pitch={viewport.pitch}
+          initialViewState={{
+            longitude: viewport.longitude,
+            latitude: viewport.latitude,
+            zoom: viewport.zoom,
+          }}
+          onLoad={e => this.geolocateControlRef.current && this.geolocateControlRef.current.trigger()}
           onViewportChange={this.viewportChange}
           onContextMenu={null}
           mapStyle={MAP_STYLE}
           width="100%"
           height="100%"
           onNativeClick={this.focus}
-          maxPitch={0}
-          mapboxApiAccessToken={MAPBOX_TOKEN}
+          mapboxAccessToken={MAPBOX_TOKEN}
           attributionControl={false}
           dragRotate={false}
           onError={(err) => this.setState({ mapError: err.error.message })}
         >
           <GeolocateControl
+            ref={this.geolocateControlRef}
             className={classes.geolocateControl}
             positionOptions={{ enableHighAccuracy: true }}
             showAccuracyCircle={false}
@@ -1038,6 +1042,7 @@ class Navigation extends Component {
             fitBoundsOptions={{ maxZoom: 10 }}
             trackUserLocation
             onViewportChange={() => {}}
+            style={{display: 'none'}}
           />
           { searchSelect && searchSelect.route
             && (
@@ -1133,7 +1138,7 @@ class Navigation extends Component {
           { searchSelect && this.renderSearchSelectMarker(searchSelect) }
           { hasNav
             && (
-            <HTMLOverlay
+            <MapOverlay
               redraw={ this.renderOverlay }
               style={{ ...cardStyle, top: 10 }}
               captureScroll
@@ -1145,7 +1150,7 @@ class Navigation extends Component {
             )}
           { searchSelect
             && (
-            <HTMLOverlay
+            <MapOverlay
               redraw={ this.renderSearchOverlay }
               captureScroll
               captureDrag
@@ -1157,7 +1162,7 @@ class Navigation extends Component {
             )}
           { search && searchLooking && !searchSelect
             && (
-            <HTMLOverlay
+            <MapOverlay
               redraw={ this.renderResearchArea }
               captureScroll
               captureDrag
@@ -1169,7 +1174,7 @@ class Navigation extends Component {
             )}
           { showPrimeAd && !hasNav && !device.prime && device.is_owner
             && (
-            <HTMLOverlay
+            <MapOverlay
               redraw={ this.renderPrimeAd }
               captureScroll
               captureDrag

--- a/src/components/Navigation/mapoverlay.js
+++ b/src/components/Navigation/mapoverlay.js
@@ -1,0 +1,29 @@
+import {Component, createElement} from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  redraw: PropTypes.func.isRequired,
+  style: PropTypes.object
+};
+
+export default class MapOverlay extends Component {
+  render() {
+    const style = Object.assign({
+      position: 'absolute',
+      left: 0,
+      top: 0,
+    }, this.props.style);
+
+    return (
+      createElement('div', {
+        ref: 'overlay',
+        style
+      },
+        this.props.redraw()
+      )
+    );
+  }
+}
+
+MapOverlay.displayName = 'MapOverlay';
+MapOverlay.propTypes = propTypes;

--- a/src/utils/geocode.js
+++ b/src/utils/geocode.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 import qs from 'query-string';
-import { WebMercatorViewport } from 'react-map-gl';
+import { WebMercatorViewport } from 'viewport-mercator-project';
 
 export const MAPBOX_TOKEN = 'pk.eyJ1IjoiY29tbWFhaSIsImEiOiJjangyYXV0c20wMGU2NDluMWR4amUydGl5In0.6Vb11S6tdX6Arpj6trRE_g';
 const HERE_API_KEY = 'FzdKQBdDlWNQfvlvreB9ukezD-fYi7uKW0rM_K9eE2E';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,7 +1154,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.18.9", "@babel/runtime@^7.2.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.18.9", "@babel/runtime@^7.2.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
   integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
@@ -1167,6 +1167,13 @@
   integrity sha512-NDYdls71fTXoU8TZHfbBWg7DiZfNzClcKui/+kyi6ppD2L1qnWW3VV6CjtaBXSUGGhiTWJ6ereOIkUvenif66Q==
   dependencies:
     regenerator-runtime "^0.13.10"
+
+"@babel/runtime@^7.12.0":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
+  integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
+  dependencies:
+    regenerator-runtime "^0.13.11"
 
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3":
   version "7.19.4"
@@ -2452,7 +2459,7 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/geojson@*", "@types/geojson@^7946.0.7":
+"@types/geojson@*":
   version "7946.0.10"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"
   integrity sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==
@@ -2463,11 +2470,6 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
-
-"@types/hammerjs@^2.0.41":
-  version "2.0.41"
-  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.41.tgz#f6ecf57d1b12d2befcce00e928a6a097c22980aa"
-  integrity sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==
 
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
@@ -2538,10 +2540,10 @@
   dependencies:
     keyv "*"
 
-"@types/mapbox-gl@^2.0.3":
-  version "2.7.6"
-  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-2.7.6.tgz#87edd38d9ac4b72be5e293472488a2e21910ad58"
-  integrity sha512-EPIfNO7WApXaFM7DuJBj+kpXmqffqJHMJ3Q9gbV/nNL23XHR0PC5CCDYbAFa4tKErm0xJd9C5kPLF6KvA/cRcA==
+"@types/mapbox-gl@^2.6.0":
+  version "2.7.11"
+  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-2.7.11.tgz#c9b9ed2ed24970aeef947609fdfcfcf826a3aa49"
+  integrity sha512-4vSwPSTQIawZTFRiTY2R74aZwAiM9gE6KGj871xdyAPpa+DmEObXxQQXqL2PsMH31/rP9nxJ2Kv0boeTVJMXVw==
   dependencies:
     "@types/geojson" "*"
 
@@ -5931,11 +5933,6 @@ gzip-size@^6.0.0:
   dependencies:
     duplexer "^0.1.2"
 
-hammerjs@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
-  integrity sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==
-
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -7714,7 +7711,7 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-mapbox-gl@^1.0.0, mapbox-gl@^1.13.2:
+mapbox-gl@^1.13.2:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.13.2.tgz#76639c44f141f8dff71b7d8f1504f2aed11f7517"
   integrity sha512-CPjtWygL+f7naL+sGHoC2JQR0DG7u+9ik6WdkjjVmz2uy0kBC2l+aKfdi3ZzUR7VKSQJ6Mc/CeCN+6iVNah+ww==
@@ -7939,14 +7936,6 @@ mixin-object@^2.0.1:
   dependencies:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
-
-mjolnir.js@^2.5.0:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.7.1.tgz#4e12590fe168b377c9c669b9c31aa5a62f8b8460"
-  integrity sha512-72BeUWgTv2cj5aZQKpwL8caNUFhXZ9bDm1hxpNj70XJQ62IBnTZmtv/WPxJvtaVNhzNo+D2U8O6ryNI0zImYcw==
-  dependencies:
-    "@types/hammerjs" "^2.0.41"
-    hammerjs "^2.0.8"
 
 mkdirp-classic@^0.5.2:
   version "0.5.3"
@@ -9437,19 +9426,12 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-map-gl@^5.3.15:
-  version "5.3.19"
-  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-5.3.19.tgz#8c012eb7328c64dc2a4bb65eeceacd4a66734f72"
-  integrity sha512-Ia8OlbFJIjC9x7XMaUCNtm179NKiD/bjQOt1R/SbBcaz35pSFPUyI0SwOnIUQ98/mR4xopL6phgIfs0B3yZhtQ==
+react-map-gl@^7.0.23:
+  version "7.0.23"
+  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-7.0.23.tgz#f6a2daf34fc3e4fb67d7ab4fa687cf6887c8810c"
+  integrity sha512-874jEtdS/fB2R4jSJKud9va0H0GlxhtiSFuUMATiniQ7A2lQnZLkZIPEWwIPkMmNZDXNlTAkxWEdSHzsqADVAw==
   dependencies:
-    "@babel/runtime" "^7.0.0"
-    "@types/geojson" "^7946.0.7"
-    "@types/mapbox-gl" "^2.0.3"
-    mapbox-gl "^1.0.0"
-    mjolnir.js "^2.5.0"
-    prop-types "^15.7.2"
-    resize-observer-polyfill "^1.5.1"
-    viewport-mercator-project "^7.0.4"
+    "@types/mapbox-gl" "^2.6.0"
 
 react-measure@^2.5.2:
   version "2.5.2"
@@ -9750,6 +9732,11 @@ regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.9:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
   integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==
 
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
 regenerator-runtime@^0.13.4:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
@@ -9851,7 +9838,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
-resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==


### PR DESCRIPTION
The purpose of updating to `react-map-gl v7` is two fold:
- Get access to `onError` for `GeolocateControl`, which can help in #338 and even browser events which are once denied to notify user of further actions.
- Potentially use MapLibre instead of Mapbox (MapLibre is an open source alternative to Mapbox. It has been released to ensure a free-to-use option is available following the announcement that Mapbox is to move to a proprietary license model.)

Current code compiles and bugs with the drag events on both navigation and drive maps are resolved. I wasn't able to dive into onViewportChange since I wasn't able to see the features affected in the demo version. Dead code parameters can be removed once the API migration is complete.