### PR TITLE
fix native pull down to refresh

### DIFF
--- a/src/components/AppDrawer/index.jsx
+++ b/src/components/AppDrawer/index.jsx
@@ -41,6 +41,9 @@ class AppDrawer extends Component {
   constructor(props) {
     super(props);
 
+    this.ref = React.createRef();
+
+    this.onRef = this.onRef.bind(this);
     this.handleDeviceSelected = this.handleDeviceSelected.bind(this);
     this.toggleDrawerOff = this.toggleDrawerOff.bind(this);
   }
@@ -48,6 +51,13 @@ class AppDrawer extends Component {
   handleDeviceSelected(dongleId) {
     this.props.dispatch(selectDevice(dongleId));
     this.toggleDrawerOff();
+  }
+
+  onRef(el) {
+    this.ref.current = el;
+    if (el) {
+      el.addEventListener('touchstart', (ev) => ev.stopPropagation());
+    }
   }
 
   toggleDrawerOff() {
@@ -64,7 +74,7 @@ class AppDrawer extends Component {
         variant={ isPermanent ? 'permanent' : 'temporary' }
         PaperProps={{ style: { width: this.props.width, top: 'auto' } }}
       >
-        <div className={classes.drawerContent}>
+        <div ref={this.onRef} className={classes.drawerContent}>
           { !isPermanent
             && (
               <Link to="/" className={ classes.logo }>

--- a/src/components/Dashboard/DeviceList.jsx
+++ b/src/components/Dashboard/DeviceList.jsx
@@ -93,13 +93,10 @@ class DeviceList extends Component {
       settingsModalDongleId: null,
     };
 
-    this.container = React.createRef();
-
     this.renderDevice = this.renderDevice.bind(this);
     this.handleOpenedSettingsModal = this.handleOpenedSettingsModal.bind(this);
     this.handleClosedSettingsModal = this.handleClosedSettingsModal.bind(this);
     this.onVisible = this.onVisible.bind(this);
-    this.onRef = this.onRef.bind(this);
   }
 
   handleOpenedSettingsModal(dongleId, ev) {
@@ -110,13 +107,6 @@ class DeviceList extends Component {
 
   handleClosedSettingsModal() {
     this.setState({ settingsModalDongleId: null });
-  }
-
-  onRef(el) {
-    this.container.current = el;
-    if (el) {
-      el.addEventListener('touchstart', (ev) => ev.stopPropagation());
-    }
   }
 
   async onVisible() {
@@ -204,7 +194,6 @@ class DeviceList extends Component {
       <>
         <VisibilityHandler onVisible={ this.onVisible } minInterval={ 10 } />
         <div
-          ref={this.onRef}
           className={`scrollstyle ${classes.deviceList}`}
           style={{ height: 'calc(100vh - 64px)' }}
         >

--- a/src/index.css
+++ b/src/index.css
@@ -28,10 +28,6 @@
   color-scheme: dark;
 }
 
-html, body {
-  overscroll-behavior-y: none;
-}
-
 html {
   font-size: 16px;
   -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
- Make native pull down to refresh work correctly on devices which aren't Safari standalone mode (PWA).
- Reduce likelihood of triggering pull down to refresh in device list drawer