### PR TITLE
CI: reduce puppeteer test time from 34s to 13s

### DIFF
--- a/src/__puppeteer__/.eslintrc.js
+++ b/src/__puppeteer__/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  globals: {
+    jestPuppeteer: 'readonly',
+    page: 'readonly',
+  },
+};

--- a/src/__puppeteer__/demo.test.js
+++ b/src/__puppeteer__/demo.test.js
@@ -1,25 +1,25 @@
 /* eslint-env jest */
-import { configureViewport, goto, sleep } from './utils';
+import { configureViewport, goto } from './utils';
 
-jest.setTimeout(60000);
+jest.setTimeout(30000);
 
 describe('demo mode', () => {
   beforeAll(async () => {
-    configureViewport();
+    await configureViewport();
   });
 
   it('should load demo route', async () => {
     await goto('/a2a0ccea32023010', { waitUntil: 'networkidle2' });
-    await sleep(2500);
 
-    const list = await expect(page).toMatchElement('.DriveList');
-    expect((await list.$$(':scope > a')).length).toBe(1);
-
+    await page.waitForSelector('.DriveList');
+    await page.waitForSelector('.DriveEntry');
     await expect(page).toClick('.DriveEntry');
-    await sleep(10000);
 
-    const video = await page.$('video');
-    const videoSrc = await page.evaluate((vid) => vid.getAttribute('src'), video);
-    expect(videoSrc.startsWith('blob:')).toBeTruthy();
+    // Wait for video src to be set
+    await page.waitForFunction(
+      (video) => video.getAttribute('src')?.startsWith('blob:'),
+      {},
+      await page.waitForSelector('video'),
+    );
   });
 });

--- a/src/__puppeteer__/offline.test.js
+++ b/src/__puppeteer__/offline.test.js
@@ -1,16 +1,16 @@
 /* eslint-env jest */
 import { configureViewport, goto } from './utils';
 
-jest.setTimeout(60000);
+jest.setTimeout(30000);
 
 describe('offline', () => {
   beforeAll(async () => {
-    configureViewport();
+    await configureViewport();
   });
 
   it('should not crash when navigating while offline', async () => {
     await goto('/a2a0ccea32023010');
-    await page.waitForSelector('.DriveEntry', { timeout: 10000 });
+    await page.waitForSelector('.DriveEntry');
 
     await page.setOfflineMode(true);
     await page.setCacheEnabled(false);

--- a/src/__puppeteer__/routing.test.js
+++ b/src/__puppeteer__/routing.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
-import { configureViewport, goto, sleep } from './utils';
+import { configureViewport, goto } from './utils';
 
-jest.setTimeout(60000);
+jest.setTimeout(30000);
 
 describe('routing', () => {
   beforeAll(async () => {
@@ -15,11 +15,9 @@ describe('routing', () => {
 
   it('load route list', async () => {
     await goto('/a2a0ccea32023010');
-    await sleep(2000);
 
-    // ".DriveList" should be visible
-    const driveList = await page.$('.DriveList');
-    expect(driveList).toBeTruthy();
+    await page.waitForSelector('.DriveList');
+    await page.waitForSelector('.DriveEntry');
 
     // Page should have one ".DriveEntry" element
     const driveEntries = await page.$$('.DriveEntry');
@@ -28,11 +26,16 @@ describe('routing', () => {
 
   it('load route from URL', async () => {
     await goto('/a2a0ccea32023010/1690488081496/1690488851596');
-    await sleep(10000);
 
-    // Should load video with src
-    const video = await page.$('video');
-    expect(video).toBeTruthy();
+    const video = await page.waitForSelector('video');
+
+    // Wait for video src to be set
+    await page.waitForFunction(
+      (vid) => vid.getAttribute('src') !== '',
+      {},
+      video,
+    );
+
     const videoSrc = await page.evaluate((vid) => vid.getAttribute('src'), video);
     expect(videoSrc.startsWith('blob:')).toBeTruthy();
   });

--- a/src/__puppeteer__/routing.test.js
+++ b/src/__puppeteer__/routing.test.js
@@ -38,5 +38,5 @@ describe('routing', () => {
 
     const videoSrc = await page.evaluate((vid) => vid.getAttribute('src'), video);
     expect(videoSrc.startsWith('blob:')).toBeTruthy();
-  });
+  }, 45000);
 });

--- a/src/__puppeteer__/routing.test.js
+++ b/src/__puppeteer__/routing.test.js
@@ -25,7 +25,7 @@ describe('routing', () => {
   });
 
   it('load route from URL', async () => {
-    await goto('/a2a0ccea32023010/1690488081496/1690488851596');
+    await goto('/a2a0ccea32023010/1690488081496/1690488851596', { timeout: 60000 });
 
     const video = await page.waitForSelector('video');
 
@@ -38,5 +38,5 @@ describe('routing', () => {
 
     const videoSrc = await page.evaluate((vid) => vid.getAttribute('src'), video);
     expect(videoSrc.startsWith('blob:')).toBeTruthy();
-  }, 45000);
+  }, 60000);
 });

--- a/src/__puppeteer__/utils.js
+++ b/src/__puppeteer__/utils.js
@@ -17,7 +17,3 @@ export const goto = async (path, options) => {
     ...options,
   });
 };
-
-export const sleep = async (ms) => new Promise((resolve) => {
-  setTimeout(resolve, ms);
-});


### PR DESCRIPTION
Replace all `await sleep(...)`s with correct Page.waitForSelector and other query selectors.

Before:
```
 PASS  src/__puppeteer__/offline.test.js (8.013 s)
 PASS  src/__puppeteer__/routing.test.js (22.464 s)
 PASS  src/__puppeteer__/demo.test.js (33.238 s)
```

After:
```
 PASS  src/__puppeteer__/offline.test.js (7.93 s)
 PASS  src/__puppeteer__/demo.test.js (8.148 s)
 PASS  src/__puppeteer__/routing.test.js (12.262 s)
```

Tests should also be less flaky now as the sleeps are not hard-coded for each test.

---

This is much faster to run locally, but GitHub actions still appears to be pretty slow :/