### PR TITLE
DriveVideo: improved buffering logic

### DIFF
--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -41,15 +41,19 @@ const getVideoState = (videoPlayer) => {
   const currentTime = videoPlayer.getCurrentTime();
   const { buffered } = videoPlayer.getInternalPlayer();
 
-  // TOOD: calculate buffer remaining
-  let hasLoaded = false;
+  let bufferRemaining = -1;
   for (let i = 0; i < buffered.length; i++) {
-    if (currentTime >= buffered.start(i) && currentTime <= buffered.end(i)) {
-      hasLoaded = true;
+    const end = buffered.end(i);
+    if (currentTime >= buffered.start(i) && currentTime <= end) {
+      bufferRemaining = end - currentTime;
+      break;
     }
   }
 
-  return { hasLoaded };
+  return {
+    bufferRemaining,
+    hasLoaded: bufferRemaining > 0,
+  };
 };
 
 class DriveVideo extends Component {

--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -302,7 +302,7 @@ class DriveVideo extends Component {
           height="100%"
           playing={Boolean(this.visibleRoute() && desiredPlaySpeed)}
           config={{
-            hlsVersion: '1.4.10',
+            hlsVersion: '1.4.8',
             hlsOptions: {
               maxBufferLength: 40,
             },

--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -37,6 +37,21 @@ const VideoOverlay = ({ loading, error }) => {
   );
 };
 
+const getVideoState = (videoPlayer) => {
+  const currentTime = videoPlayer.getCurrentTime();
+  const { buffered } = videoPlayer.getInternalPlayer();
+
+  // TOOD: calculate buffer remaining
+  let hasLoaded = false;
+  for (let i = 0; i < buffered.length; i++) {
+    if (currentTime >= buffered.start(i) && currentTime <= buffered.end(i)) {
+      hasLoaded = true;
+    }
+  }
+
+  return { hasLoaded };
+};
+
 class DriveVideo extends Component {
   constructor(props) {
     super(props);
@@ -91,17 +106,7 @@ class DriveVideo extends Component {
       videoPlayer.seekTo(this.currentVideoTime(), 'seconds');
     }
 
-    // TODO: refactor and re-use this logic in syncVideo
-    const { buffered } = videoPlayer.getInternalPlayer();
-    const currentTime = videoPlayer.getCurrentTime();
-
-    let hasLoaded = false;
-    for (let i = 0; i < buffered.length; i++) {
-      if (currentTime >= buffered.start(i) && currentTime <= buffered.end(i)) {
-        hasLoaded = true;
-      }
-    }
-
+    const { hasLoaded } = getVideoState(videoPlayer);
     const { readyState } = videoPlayer.getInternalPlayer();
     if (!hasLoaded || readyState < 2) {
       dispatch(bufferVideo(true));
@@ -232,6 +237,7 @@ class DriveVideo extends Component {
 
     const internalPlayer = videoPlayer.getInternalPlayer();
 
+    // TODO: refactor
     const sufficientBuffer = Math.min(videoPlayer.getDuration() - videoPlayer.getCurrentTime(), 30);
     const hasSufficientBuffer = videoPlayer.getSecondsLoaded() - videoPlayer.getCurrentTime() >= sufficientBuffer;
     const hasLoaded = videoPlayer.getSecondsLoaded() > videoPlayer.getCurrentTime();

--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -302,7 +302,7 @@ class DriveVideo extends Component {
           height="100%"
           playing={Boolean(this.visibleRoute() && desiredPlaySpeed)}
           config={{
-            hlsVersion: '1.4.8',
+            hlsVersion: '1.4.10',
             hlsOptions: {
               maxBufferLength: 40,
             },

--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -241,10 +241,9 @@ class DriveVideo extends Component {
 
     const internalPlayer = videoPlayer.getInternalPlayer();
 
-    // TODO: refactor
     const sufficientBuffer = Math.min(videoPlayer.getDuration() - videoPlayer.getCurrentTime(), 30);
-    const hasSufficientBuffer = videoPlayer.getSecondsLoaded() - videoPlayer.getCurrentTime() >= sufficientBuffer;
-    const hasLoaded = videoPlayer.getSecondsLoaded() > videoPlayer.getCurrentTime();
+    const { hasLoaded, bufferRemaining } = getVideoState(videoPlayer);
+    const hasSufficientBuffer = bufferRemaining >= sufficientBuffer;
     if (isBufferingVideo && hasSufficientBuffer && internalPlayer.readyState >= 2) {
       dispatch(bufferVideo(false));
     } else if (isBufferingVideo || !hasLoaded || internalPlayer.readyState < 2) {

--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -91,7 +91,17 @@ class DriveVideo extends Component {
       videoPlayer.seekTo(this.currentVideoTime(), 'seconds');
     }
 
-    const hasLoaded = videoPlayer.getSecondsLoaded() > videoPlayer.getCurrentTime();
+    // TODO: refactor and re-use this logic in syncVideo
+    const { buffered } = videoPlayer.getInternalPlayer();
+    const currentTime = videoPlayer.getCurrentTime();
+
+    let hasLoaded = false;
+    for (let i = 0; i < buffered.length; i++) {
+      if (currentTime >= buffered.start(i) && currentTime <= buffered.end(i)) {
+        hasLoaded = true;
+      }
+    }
+
     const { readyState } = videoPlayer.getInternalPlayer();
     if (!hasLoaded || readyState < 2) {
       dispatch(bufferVideo(true));


### PR DESCRIPTION
Handle seeking backwards by using `buffered` property (`TimeRanges` object) to determine whether content is loaded
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/buffered

**Testing:**
- [x] Chrome
- [x] Chrome on Android
- [x] Firefox
- [x] Safari on iOS