### PR TITLE
navigation: fix duplicate place name in address

### DIFF
--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -806,12 +806,13 @@ class Navigation extends Component {
     } });
 
     const pos = this.itemLoc(searchSelect);
+    console.log(searchSelect);
     NavigationApi.setDestination(
       dongleId,
       pos.lat,
       pos.lng,
-      Utils.formatSearchName(searchSelect),
-      Utils.formatSearchDetails(searchSelect),
+      Utils.formatPlaceName(searchSelect),
+      Utils.formatPlaceAddress(searchSelect, 'state'),
     )
       .then((resp) => {
         if (resp.error) {
@@ -857,8 +858,8 @@ class Navigation extends Component {
       dongleId,
       pos.lat,
       pos.lng,
-      Utils.formatSearchName(searchSelect),
-      Utils.formatSearchDetails(searchSelect),
+      Utils.formatPlaceName(searchSelect),
+      Utils.formatPlaceAddress(searchSelect, 'state'),
       'favorite',
       label,
     )
@@ -1254,7 +1255,7 @@ class Navigation extends Component {
             { search.map((item) => (
               <div key={ item.id } className={ classes.overlaySearchItem } onClick={ () => this.onSearchSelect(item, 'list') }>
                 <Typography>
-                  { Utils.formatSearchName(item) }
+                  { Utils.formatPlaceName(item) }
                   <span className={ classes.overlaySearchDetails }>
                     { Utils.formatSearchList(item) }
                   </span>
@@ -1278,7 +1279,7 @@ class Navigation extends Component {
     const isCar = searchSelect.resultType === 'car';
 
     const isIos = /iphone|ipad|ipod/.test(window.navigator.userAgent.toLowerCase());
-    const title = isCar ? device.alias : Utils.formatSearchName(searchSelect);
+    const title = isCar ? device.alias : Utils.formatPlaceName(searchSelect);
     const { lat, lng } = searchSelect.position;
 
     let geoUri;
@@ -1382,8 +1383,8 @@ class Navigation extends Component {
           </div>
         </div>
         <Typography className={ classes.searchSelectBoxDetails }>
-          {isCar && `${Utils.formatSearchName(searchSelect)}, `}
-          {Utils.formatSearchAddress(searchSelect)}
+          {isCar && `${Utils.formatPlaceName(searchSelect)}, `}
+          {Utils.formatPlaceAddress(searchSelect, 'all')}
         </Typography>
       </div>
     );

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -811,7 +811,7 @@ class Navigation extends Component {
       pos.lat,
       pos.lng,
       Utils.formatSearchName(searchSelect),
-      Utils.formatSearchAddress(searchSelect),
+      Utils.formatSearchDetails(searchSelect),
     )
       .then((resp) => {
         if (resp.error) {
@@ -858,7 +858,7 @@ class Navigation extends Component {
       pos.lat,
       pos.lng,
       Utils.formatSearchName(searchSelect),
-      Utils.formatSearchAddress(searchSelect),
+      Utils.formatSearchDetails(searchSelect),
       'favorite',
       label,
     )
@@ -1383,7 +1383,7 @@ class Navigation extends Component {
         </div>
         <Typography className={ classes.searchSelectBoxDetails }>
           {isCar && `${Utils.formatSearchName(searchSelect)}, `}
-          {Utils.formatSearchDetails(searchSelect)}
+          {Utils.formatSearchAddress(searchSelect)}
         </Typography>
       </div>
     );

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -1384,7 +1384,7 @@ class Navigation extends Component {
         </div>
         <Typography className={ classes.searchSelectBoxDetails }>
           {isCar && `${Utils.formatPlaceName(searchSelect)}, `}
-          {Utils.formatPlaceAddress(searchSelect, 'all')}
+          {Utils.formatPlaceAddress(searchSelect, 'state')}
         </Typography>
       </div>
     );

--- a/src/components/Navigation/utils.js
+++ b/src/components/Navigation/utils.js
@@ -71,15 +71,12 @@ export function formatPlaceAddress(item, details = 'all') {
     }
   }
 
+  // NOTE: this is a hack to remove the name from the address. it's necessary
+  //       for cases where we only have the address label, without individual
+  //       address components (search results and favourites).
   if (details !== 'all') {
     const name = formatPlaceName(item);
-    if (res.startsWith(name)) {
-      // NOTE: this is a hack to remove the name from the address.
-      //       it's needed for situations where we only have the address label
-      //       and not the individual address components.
-      console.warn('formatSearchAddress: removing name from address', { name, address: res, details });
-      res = res.substring(name.length + 2);
-    }
+    if (res.startsWith(name)) res = res.substring(name.length + 2);
   }
 
   return res;

--- a/src/components/Navigation/utils.js
+++ b/src/components/Navigation/utils.js
@@ -48,32 +48,44 @@ export function formatPlaceName(item) {
  * @returns {string}
  */
 export function formatPlaceAddress(item, details = 'all') {
+  const { address, resultType } = item;
   let res;
 
-  if (['street', 'city'].some((key) => !item.address[key])) {
-    res = item.address.label;
+  if (!address.city || ['street', 'streets'].every((key) => !address[key])) {
+    res = address.label;
   } else {
-    if (!item.resultType) console.warn('formatSearchAddress: missing resultType', item);
+    if (!resultType) console.warn('formatSearchAddress: missing resultType', item);
 
     res = '';
-    if (details === 'all' || ['car', 'place'].includes(item.resultType)) {
-      const { houseNumber, street } = item.address;
+
+    if (details === 'all' || ['car', 'place'].includes(resultType)) {
+      const { houseNumber, street, streets } = address;
       if (houseNumber) res += `${houseNumber} `;
-      res += `${street}, `;
+      if (streets) {
+        res += streets.join(' & ');
+      } else {
+        res += street;
+      }
+      res += ', ';
     }
-    const { city, stateCode, postalCode, countryName } = item.address;
+
+    const { city } = address;
     res += `${city}`;
+
     if (['state', 'all'].includes(details)) {
-      res += ',';
-      if (stateCode) res += ` ${stateCode}`;
-      res += ` ${postalCode}`;
+      const { stateCode, postalCode, countryName } = address;
+      if (stateCode || postalCode) {
+        res += ',';
+        if (stateCode) res += ` ${stateCode}`;
+        res += ` ${postalCode}`;
+      }
       if (details === 'all' && countryName) res += `, ${countryName}`;
     }
   }
 
   // NOTE: this is a hack to remove the name from the address. it's necessary
   //       for cases where we only have the address label, without individual
-  //       address components (search results and favourites).
+  //       address components (search results and favorites).
   if (details !== 'all') {
     const name = formatPlaceName(item);
     if (res.startsWith(name)) res = res.substring(name.length + 2);

--- a/src/components/Navigation/utils.test.js
+++ b/src/components/Navigation/utils.test.js
@@ -2,7 +2,7 @@
 import * as Utils from './utils';
 
 describe('navigation formatting utils', () => {
-  describe('formats search results correctly', () => {
+  describe('location formatting', () => {
     const testCases = [
       {
         // from mapbox api
@@ -111,19 +111,49 @@ describe('navigation formatting utils', () => {
         details: 'London, SW1E 6',
         searchList: ', London (0.8 mi)',
       },
+      {
+        // from mapbox api
+        item: {
+          title: '1441 Rd & State Road 76, Chimayo, NM 87522, United States',
+          resultType: 'intersection',
+          address: {
+            label: '1441 Rd & State Road 76, Chimayo, NM 87522, United States',
+            countryCode: 'USA',
+            countryName: 'United States',
+            stateCode: 'NM',
+            state: 'New Mexico',
+            county: 'Rio Arriba',
+            city: 'Chimayo',
+            streets: [
+              '1441 Rd',
+              'State Road 76',
+            ],
+            postalCode: '87522',
+          },
+          distance: 1092925,
+        },
+
+        // expected
+        name: '1441 Rd & State Road 76',
+        address: '1441 Rd & State Road 76, Chimayo, NM 87522, United States',
+        details: 'Chimayo, NM 87522',
+        searchList: ', Chimayo (679.1 mi)',
+      },
     ];
 
     testCases.forEach((testCase) => {
-      const { item } = testCase;
+      test(testCase.address, () => {
+        const { item } = testCase;
 
-      expect(Utils.formatPlaceName(item)).toBe(testCase.name);
-      expect(Utils.formatPlaceAddress(item, 'all')).toBe(testCase.address);
-      expect(Utils.formatPlaceAddress(item, 'state')).toBe(testCase.details);
-      expect(Utils.formatSearchList(item)).toBe(testCase.searchList);
+        expect(Utils.formatPlaceName(item)).toBe(testCase.name);
+        expect(Utils.formatPlaceAddress(item, 'all')).toBe(testCase.address);
+        expect(Utils.formatPlaceAddress(item, 'state')).toBe(testCase.details);
+        expect(Utils.formatSearchList(item)).toBe(testCase.searchList);
+      });
     });
   });
 
-  it('formats favorites correctly', () => {
+  describe('favorite formatting', () => {
     const testCases = [
       {
         // from favorites
@@ -145,11 +175,13 @@ describe('navigation formatting utils', () => {
     ];
 
     testCases.forEach((testCase) => {
-      const { item } = testCase;
+      test(testCase.address, () => {
+        const { item } = testCase;
 
-      expect(Utils.formatPlaceName(item)).toBe(testCase.name);
-      expect(Utils.formatPlaceAddress(item, 'all')).toBe(testCase.address);
-      expect(Utils.formatPlaceAddress(item, 'state')).toBe(testCase.details);
+        expect(Utils.formatPlaceName(item)).toBe(testCase.name);
+        expect(Utils.formatPlaceAddress(item, 'all')).toBe(testCase.address);
+        expect(Utils.formatPlaceAddress(item, 'state')).toBe(testCase.details);
+      });
     });
   });
 });

--- a/src/components/Navigation/utils.test.js
+++ b/src/components/Navigation/utils.test.js
@@ -8,33 +8,34 @@ describe('navigation formatting utils', () => {
         // from mapbox api
         item: {
           title: 'Taco Bell',
-          distance: 1234,
+          resultType: 'place',
           address: {
-            label: 'Taco Bell, 2011 Camino del Rio N, San Diego, CA 92108, United States',
+            label: 'Taco Bell, 2626 El Cajon Blvd, San Diego, CA 92104, United States',
             countryCode: 'USA',
             countryName: 'United States',
             stateCode: 'CA',
             state: 'California',
             county: 'San Diego',
             city: 'San Diego',
-            district: 'Mission Valley East',
-            street: 'Camino del Rio N',
-            postalCode: '92108',
-            houseNumber: '2011',
+            district: 'North Park',
+            street: 'El Cajon Blvd',
+            postalCode: '92104',
+            houseNumber: '2626',
           },
+          distance: 5614,
         },
 
         // expected
         name: 'Taco Bell',
-        details: '2011 Camino del Rio N, San Diego, CA 92108',
-        address: '2011 Camino del Rio N, San Diego, CA 92108, United States',
-        searchList: ', 2011 Camino del Rio N, San Diego (0.8 mi)',
+        address: '2626 El Cajon Blvd, San Diego, CA 92104, United States',
+        details: '2626 El Cajon Blvd, San Diego, CA 92104',
+        searchList: ', 2626 El Cajon Blvd, San Diego (3.5 mi)',
       },
       {
         // from mapbox api
         item: {
           title: '1441 State St, San Diego, CA 92101-3421, United States',
-          distance: 1234,
+          resultType: 'houseNumber',
           address: {
             label: '1441 State St, San Diego, CA 92101-3421, United States',
             countryCode: 'USA',
@@ -48,19 +49,20 @@ describe('navigation formatting utils', () => {
             postalCode: '92101-3421',
             houseNumber: '1441',
           },
+          distance: 1234,
         },
 
         // expected
         name: '1441 State St',
-        details: 'San Diego, CA 92101-3421',
         address: '1441 State St, San Diego, CA 92101-3421, United States',
+        details: 'San Diego, CA 92101-3421',
         searchList: ', San Diego (0.8 mi)',
       },
       {
         // from mapbox api
         item: {
           title: 'Taco Bell',
-          distance: 38190,
+          resultType: 'place',
           address: {
             label: 'Taco Bell, Irlam Drive, Liverpool, L32 8, United Kingdom',
             countryCode: 'GBR',
@@ -73,19 +75,20 @@ describe('navigation formatting utils', () => {
             street: 'Irlam Drive',
             postalCode: 'L32 8',
           },
+          distance: 38190,
         },
 
         // expected
         name: 'Taco Bell',
-        details: 'Irlam Drive, Liverpool, L32 8',
         address: 'Irlam Drive, Liverpool, L32 8, United Kingdom',
+        details: 'Irlam Drive, Liverpool, L32 8',
         searchList: ', Irlam Drive, Liverpool (23.7 mi)',
       },
       {
         // from mapbox api
         item: {
           title: '123 Victoria Street, London, SW1E 6, United Kingdom',
-          distance: 1234,
+          resultType: 'houseNumber',
           address: {
             label: '123 Victoria Street, London, SW1E 6, United Kingdom',
             countryCode: 'GBR',
@@ -99,12 +102,13 @@ describe('navigation formatting utils', () => {
             postalCode: 'SW1E 6',
             houseNumber: '123',
           },
+          distance: 1234,
         },
 
         // expected
         name: '123 Victoria Street',
-        details: 'London, SW1E 6',
         address: '123 Victoria Street, London, SW1E 6, United Kingdom',
+        details: 'London, SW1E 6',
         searchList: ', London (0.8 mi)',
       },
     ];
@@ -112,9 +116,9 @@ describe('navigation formatting utils', () => {
     testCases.forEach((testCase) => {
       const { item } = testCase;
 
-      expect(Utils.formatSearchName(item)).toBe(testCase.name);
-      expect(Utils.formatSearchDetails(item)).toBe(testCase.details);
-      expect(Utils.formatSearchAddress(item)).toBe(testCase.address);
+      expect(Utils.formatPlaceName(item)).toBe(testCase.name);
+      expect(Utils.formatPlaceAddress(item, 'all')).toBe(testCase.address);
+      expect(Utils.formatPlaceAddress(item, 'state')).toBe(testCase.details);
       expect(Utils.formatSearchList(item)).toBe(testCase.searchList);
     });
   });
@@ -125,6 +129,7 @@ describe('navigation formatting utils', () => {
         // from favorites
         item: {
           title: '123 San Diego St',
+          resultType: 'houseNumber',
           distance: 1234,
           address: {
             label: '123 San Diego St, San Diego, CA 92123, United States',
@@ -142,9 +147,9 @@ describe('navigation formatting utils', () => {
     testCases.forEach((testCase) => {
       const { item } = testCase;
 
-      expect(Utils.formatSearchName(item)).toBe(testCase.name);
-      expect(Utils.formatSearchAddress(item)).toBe(testCase.address);
-      expect(Utils.formatSearchDetails(item)).toBe(testCase.details);
+      expect(Utils.formatPlaceName(item)).toBe(testCase.name);
+      expect(Utils.formatPlaceAddress(item, 'all')).toBe(testCase.address);
+      expect(Utils.formatPlaceAddress(item, 'state')).toBe(testCase.details);
     });
   });
 });

--- a/src/components/Navigation/utils.test.js
+++ b/src/components/Navigation/utils.test.js
@@ -113,8 +113,8 @@ describe('navigation formatting utils', () => {
       const { item } = testCase;
 
       expect(Utils.formatSearchName(item)).toBe(testCase.name);
-      expect(Utils.formatSearchAddress(item)).toBe(testCase.address);
       expect(Utils.formatSearchDetails(item)).toBe(testCase.details);
+      expect(Utils.formatSearchAddress(item)).toBe(testCase.address);
       expect(Utils.formatSearchList(item)).toBe(testCase.searchList);
     });
   });

--- a/src/components/Navigation/utils.test.js
+++ b/src/components/Navigation/utils.test.js
@@ -26,9 +26,8 @@ describe('navigation formatting utils', () => {
 
         // expected
         name: 'Taco Bell',
-        fullAddress: '2011 Camino del Rio N, San Diego, CA 92108, United States',
-        address: '2011 Camino del Rio N, San Diego',
-        details: '2011 Camino del Rio N, San Diego',
+        details: '2011 Camino del Rio N, San Diego, CA 92108',
+        address: '2011 Camino del Rio N, San Diego, CA 92108, United States',
         searchList: ', 2011 Camino del Rio N, San Diego (0.8 mi)',
       },
       {
@@ -53,15 +52,15 @@ describe('navigation formatting utils', () => {
 
         // expected
         name: '1441 State St',
-        fullAddress: '1441 State St, San Diego, CA 92101-3421, United States',
-        address: 'San Diego',
-        details: 'San Diego',
+        details: 'San Diego, CA 92101-3421',
+        address: '1441 State St, San Diego, CA 92101-3421, United States',
         searchList: ', San Diego (0.8 mi)',
       },
       {
         // from mapbox api
         item: {
           title: 'Taco Bell',
+          distance: 38190,
           address: {
             label: 'Taco Bell, Irlam Drive, Liverpool, L32 8, United Kingdom',
             countryCode: 'GBR',
@@ -74,15 +73,39 @@ describe('navigation formatting utils', () => {
             street: 'Irlam Drive',
             postalCode: 'L32 8',
           },
-          distance: 38190,
         },
 
         // expected
         name: 'Taco Bell',
-        fullAddress: 'Irlam Drive, Liverpool, L32 8, United Kingdom',
-        address: 'Irlam Drive, Liverpool',
-        details: 'Irlam Drive, Liverpool',
+        details: 'Irlam Drive, Liverpool, L32 8',
+        address: 'Irlam Drive, Liverpool, L32 8, United Kingdom',
         searchList: ', Irlam Drive, Liverpool (23.7 mi)',
+      },
+      {
+        // from mapbox api
+        item: {
+          title: '123 Victoria Street, London, SW1E 6, United Kingdom',
+          distance: 1234,
+          address: {
+            label: '123 Victoria Street, London, SW1E 6, United Kingdom',
+            countryCode: 'GBR',
+            countryName: 'United Kingdom',
+            state: 'England',
+            countyCode: 'LDN',
+            county: 'London',
+            city: 'London',
+            district: 'St James\'s Park',
+            street: 'Victoria Street',
+            postalCode: 'SW1E 6',
+            houseNumber: '123',
+          },
+        },
+
+        // expected
+        name: '123 Victoria Street',
+        details: 'London, SW1E 6',
+        address: '123 Victoria Street, London, SW1E 6, United Kingdom',
+        searchList: ', London (0.8 mi)',
       },
     ];
 
@@ -90,8 +113,7 @@ describe('navigation formatting utils', () => {
       const { item } = testCase;
 
       expect(Utils.formatSearchName(item)).toBe(testCase.name);
-      expect(Utils.formatSearchAddress(item, true)).toBe(testCase.fullAddress);
-      expect(Utils.formatSearchAddress(item, false)).toBe(testCase.address);
+      expect(Utils.formatSearchAddress(item)).toBe(testCase.address);
       expect(Utils.formatSearchDetails(item)).toBe(testCase.details);
       expect(Utils.formatSearchList(item)).toBe(testCase.searchList);
     });


### PR DESCRIPTION
Resolve place name appearing in place details for street addresses. In openpilot, the address will be on both lines, for example:
![image](https://github.com/commaai/connect/assets/4038174/b1f0f69d-fd76-4bf4-bc55-4a0be72fe2cf)
