### PR TITLE
improve TimeFilter for custom date

### DIFF
--- a/src/components/AppHeader/TimeFilter.jsx
+++ b/src/components/AppHeader/TimeFilter.jsx
@@ -120,12 +120,12 @@ class TimeSelect extends Component {
   }
 
   handleSave() {
-      this.props.dispatch(selectTimeFilter(this.state.start, this.state.end));
-      this.setState({
-        showPicker: false,
-        start: null,
-        end: null,
-      });
+    this.props.dispatch(selectTimeFilter(this.state.start, this.state.end));
+    this.setState({
+      showPicker: false,
+      start: null,
+      end: null,
+    });
   }
 
   selectedOption() {

--- a/src/components/AppHeader/TimeFilter.jsx
+++ b/src/components/AppHeader/TimeFilter.jsx
@@ -106,7 +106,7 @@ class TimeSelect extends Component {
   changeStart(event) {
     if (event.target.valueAsDate) {
       this.setState({
-        start: new Date(event.target.valueAsDate.getUTCFullYear(),  event.target.valueAsDate.getUTCMonth(),  event.target.valueAsDate.getUTCDate()).getTime(),
+        start: new Date(event.target.valueAsDate.getUTCFullYear(), event.target.valueAsDate.getUTCMonth(), event.target.valueAsDate.getUTCDate()).getTime(),
       });
     }
   }
@@ -114,7 +114,7 @@ class TimeSelect extends Component {
   changeEnd(event) {
     if (event.target.valueAsDate) {
       this.setState({
-        end: new Date(event.target.valueAsDate.getUTCFullYear(),  event.target.valueAsDate.getUTCMonth(),  event.target.valueAsDate.getUTCDate(),23,59,59).getTime(),
+        end: new Date(event.target.valueAsDate.getUTCFullYear(), event.target.valueAsDate.getUTCMonth(), event.target.valueAsDate.getUTCDate(),23,59,59).getTime(),
       });
     }
   }

--- a/src/components/AppHeader/TimeFilter.jsx
+++ b/src/components/AppHeader/TimeFilter.jsx
@@ -62,6 +62,7 @@ class TimeSelect extends Component {
 
     this.state = {
       showPicker: false,
+      showError: false,
     };
 
     this.handleSelectChange = this.handleSelectChange.bind(this);
@@ -100,6 +101,7 @@ class TimeSelect extends Component {
   handleClose() {
     this.setState({
       showPicker: false,
+      showError: false,
     });
   }
 
@@ -120,12 +122,19 @@ class TimeSelect extends Component {
   }
 
   handleSave() {
-    this.props.dispatch(selectTimeFilter(this.state.start, this.state.end));
-    this.setState({
-      showPicker: false,
-      start: null,
-      end: null,
-    });
+    if (this.state.end - this.state.start < 0){
+      this.setState({
+        showError: true,
+      });
+    } else {
+      this.props.dispatch(selectTimeFilter(this.state.start, this.state.end));
+      this.setState({
+        showPicker: false,
+        showError: false,
+        start: null,
+        end: null,
+      });
+    }
   }
 
   selectedOption() {
@@ -222,6 +231,7 @@ class TimeSelect extends Component {
               />
             </div>
             <Divider />
+            {this.state.showError? <Typography variant="body2">Invalid TimeFilter</Typography> : null}
             <div className={classes.buttonGroup}>
               <Button variant="contained" className={ classes.cancelButton } onClick={this.handleClose}>
                 Cancel

--- a/src/components/AppHeader/TimeFilter.jsx
+++ b/src/components/AppHeader/TimeFilter.jsx
@@ -114,7 +114,7 @@ class TimeSelect extends Component {
   changeEnd(event) {
     if (event.target.valueAsDate) {
       this.setState({
-        end: new Date(event.target.valueAsDate.getUTCFullYear(),  event.target.valueAsDate.getUTCMonth(),  event.target.valueAsDate.getUTCDate()).getTime(),
+        end: new Date(event.target.valueAsDate.getUTCFullYear(),  event.target.valueAsDate.getUTCMonth(),  event.target.valueAsDate.getUTCDate(),23,59,59).getTime(),
       });
     }
   }

--- a/src/components/AppHeader/TimeFilter.jsx
+++ b/src/components/AppHeader/TimeFilter.jsx
@@ -123,7 +123,6 @@ class TimeSelect extends Component {
       this.props.dispatch(selectTimeFilter(this.state.start, this.state.end));
       this.setState({
         showPicker: false,
-        showError: false,
         start: null,
         end: null,
       });

--- a/src/components/AppHeader/TimeFilter.jsx
+++ b/src/components/AppHeader/TimeFilter.jsx
@@ -62,7 +62,6 @@ class TimeSelect extends Component {
 
     this.state = {
       showPicker: false,
-      showError: false,
     };
 
     this.handleSelectChange = this.handleSelectChange.bind(this);
@@ -101,14 +100,13 @@ class TimeSelect extends Component {
   handleClose() {
     this.setState({
       showPicker: false,
-      showError: false,
     });
   }
 
   changeStart(event) {
     if (event.target.valueAsDate) {
       this.setState({
-        start: event.target.valueAsDate.setHours(0, 0, 0, 0),
+        start: new Date(event.target.valueAsDate.getUTCFullYear(),  event.target.valueAsDate.getUTCMonth(),  event.target.valueAsDate.getUTCDate()).getTime(),
       });
     }
   }
@@ -116,17 +114,12 @@ class TimeSelect extends Component {
   changeEnd(event) {
     if (event.target.valueAsDate) {
       this.setState({
-        end: event.target.valueAsDate.setHours(23, 59, 59, 999),
+        end: new Date(event.target.valueAsDate.getUTCFullYear(),  event.target.valueAsDate.getUTCMonth(),  event.target.valueAsDate.getUTCDate()).getTime(),
       });
     }
   }
 
   handleSave() {
-    if (this.state.end - this.state.start < 0){
-      this.setState({
-        showError: true,
-      });
-    } else {
       this.props.dispatch(selectTimeFilter(this.state.start, this.state.end));
       this.setState({
         showPicker: false,
@@ -134,7 +127,6 @@ class TimeSelect extends Component {
         start: null,
         end: null,
       });
-    }
   }
 
   selectedOption() {
@@ -224,14 +216,13 @@ class TimeSelect extends Component {
               <input
                 label="End date"
                 type="date"
-                min={ minDate }
+                min={ startDate }
                 max={ maxDate }
                 onChange={this.changeEnd}
                 value={ endDate }
               />
             </div>
             <Divider />
-            {this.state.showError? <Typography variant="body2">Invalid TimeFilter</Typography> : null}
             <div className={classes.buttonGroup}>
               <Button variant="contained" className={ classes.cancelButton } onClick={this.handleClose}>
                 Cancel


### PR DESCRIPTION
Fixes #462 - This was due to input type of "date" being a timezone-less date and using the local time instead of GMT time. This is discussed [here](https://austinfrance.wordpress.com/2012/07/09/html5-date-input-field-and-valueasdate-timezone-gotcha-3/)

tl;dr: from the calendar we pick a date (`27th July 2012 00:00:00 BST (GMT+1)`) which gets converted to (`23:00:00 on 26th July 2012`) when getting through `valueAsDate`

The fix is to use UTC to prevent this confusion.

Also set `minDate` to be `startDate` for end date selection, this prevents users to be able to choose a date that is before the start date. Before there was no catch for this.

Before fix:
![image](https://github.com/commaai/connect/assets/65101411/ff60a81e-5e74-4ee0-8a61-8f373e7a8c4c)


After fix:
![image](https://github.com/commaai/connect/assets/65101411/e3129c86-024f-4ada-b18e-cd0859928134)