### PR TITLE
add styling to make hyperlinks more obvious

### DIFF
--- a/src/components/Prime/PrimeCheckout.jsx
+++ b/src/components/Prime/PrimeCheckout.jsx
@@ -16,6 +16,21 @@ import { primeNav, analyticsEvent } from '../../actions';
 import { ErrorOutline, InfoOutline } from '../../icons';
 
 const styles = () => ({
+  linkHighlight: {
+    '&:link': {
+      color: Colors.green300,
+    },
+    '&:visited': {
+      color: Colors.green300,
+    },
+    '&:active': {
+      color: Colors.green300,
+    },
+    
+    '&:hover': {
+      color: Colors.green400,
+    },
+  },
   primeBox: {
     display: 'flex',
     flexDirection: 'column',
@@ -313,13 +328,13 @@ class PrimeCheckout extends Component {
         disabledDataPlanText = 'Standard plan not available, detected a third-party SIM.';
       } else if (!['blue', 'magenta_new', 'webbing'].includes(subscribeInfo.sim_type)) {
         disabledDataPlanText = ['Standard plan not available, old SIM type detected, new SIM cards are available in the ',
-          <a key={1} href="https://comma.ai/shop/comma-prime-sim">shop</a>];
+          <a className={ classes.linkHighlight} key={1}  href="https://comma.ai/shop/comma-prime-sim">shop</a>];
       } else if (subscribeInfo.sim_usable === false && subscribeInfo.sim_type === 'blue') {
         disabledDataPlanText = ['Standard plan not available, SIM has been canceled and is therefore no longer usable, new SIM cards are available in the ',
-          <a key={1} href="https://comma.ai/shop/comma-prime-sim">shop</a>];
+          <a className={ classes.linkHighlight} key={1}  href="https://comma.ai/shop/comma-prime-sim">shop</a>];
       } else if (subscribeInfo.sim_usable === false) {
         disabledDataPlanText = ['Standard plan not available, SIM is no longer usable, new SIM cards are available in the ',
-          <a key={1} href="https://comma.ai/shop/comma-prime-sim">shop</a>];
+          <a className={ classes.linkHighlight} key={1} href="https://comma.ai/shop/comma-prime-sim">shop</a>];
       }
     }
 
@@ -408,7 +423,7 @@ class PrimeCheckout extends Component {
         <div style={ blockMargin }>
           <Typography className={ classes.learnMore }>
             {'Learn more about comma prime from our '}
-            <a target="_blank" href="https://comma.ai/connect#faq" rel="noreferrer">FAQ</a>
+            <a className={ classes.linkHighlight} target="_blank" href="https://comma.ai/connect#faq" rel="noreferrer">FAQ</a>
           </Typography>
         </div>
         { error && (

--- a/src/components/Prime/PrimeCheckout.jsx
+++ b/src/components/Prime/PrimeCheckout.jsx
@@ -18,16 +18,19 @@ import { ErrorOutline, InfoOutline } from '../../icons';
 const styles = () => ({
   linkHighlight: {
     '&:link': {
+      textDecoration: "underline",
       color: Colors.green300,
     },
     '&:visited': {
+      textDecoration: "underline",
       color: Colors.green300,
     },
     '&:active': {
+      textDecoration: "underline",
       color: Colors.green300,
     },
-    
     '&:hover': {
+      textDecoration: "underline",
       color: Colors.green400,
     },
   },
@@ -328,10 +331,10 @@ class PrimeCheckout extends Component {
         disabledDataPlanText = 'Standard plan not available, detected a third-party SIM.';
       } else if (!['blue', 'magenta_new', 'webbing'].includes(subscribeInfo.sim_type)) {
         disabledDataPlanText = ['Standard plan not available, old SIM type detected, new SIM cards are available in the ',
-          <a className={ classes.linkHighlight} key={1}  href="https://comma.ai/shop/comma-prime-sim">shop</a>];
+          <a className={ classes.linkHighlight} key={1} href="https://comma.ai/shop/comma-prime-sim">shop</a>];
       } else if (subscribeInfo.sim_usable === false && subscribeInfo.sim_type === 'blue') {
         disabledDataPlanText = ['Standard plan not available, SIM has been canceled and is therefore no longer usable, new SIM cards are available in the ',
-          <a className={ classes.linkHighlight} key={1}  href="https://comma.ai/shop/comma-prime-sim">shop</a>];
+          <a className={ classes.linkHighlight} key={1} href="https://comma.ai/shop/comma-prime-sim">shop</a>];
       } else if (subscribeInfo.sim_usable === false) {
         disabledDataPlanText = ['Standard plan not available, SIM is no longer usable, new SIM cards are available in the ',
           <a className={ classes.linkHighlight} key={1} href="https://comma.ai/shop/comma-prime-sim">shop</a>];

--- a/src/components/Prime/PrimeManage.jsx
+++ b/src/components/Prime/PrimeManage.jsx
@@ -16,6 +16,21 @@ import { ErrorOutline, InfoOutline } from '../../icons';
 import { primeNav, primeGetSubscription, analyticsEvent } from '../../actions';
 
 const styles = (theme) => ({
+  linkHighlight: {
+    '&:link': {
+      color: Colors.green300,
+    },
+    '&:visited': {
+      color: Colors.green300,
+    },
+    '&:active': {
+      color: Colors.green300,
+    },
+    
+    '&:hover': {
+      color: Colors.green400,
+    },
+  },
   primeBox: {
     display: 'flex',
     flexDirection: 'column',
@@ -442,7 +457,7 @@ class PrimeManage extends Component {
                         Your prime subscription will be canceled on May 15th unless you replace the
                         SIM
                         card in your device. A new SIM card can be ordered from the
-                        <a href="https://comma.ai/shop/comma-prime-sim">shop</a>
+                        <a className={ classes.linkHighlight} href="https://comma.ai/shop/comma-prime-sim">shop</a>
                         .
                         Use discount code SIMSWAP at checkout to receive a free SIM card.
                       </Typography>

--- a/src/components/Prime/PrimeManage.jsx
+++ b/src/components/Prime/PrimeManage.jsx
@@ -18,16 +18,19 @@ import { primeNav, primeGetSubscription, analyticsEvent } from '../../actions';
 const styles = (theme) => ({
   linkHighlight: {
     '&:link': {
+      textDecoration: "underline",
       color: Colors.green300,
     },
     '&:visited': {
+      textDecoration: "underline",
       color: Colors.green300,
     },
     '&:active': {
+      textDecoration: "underline",
       color: Colors.green300,
     },
-    
     '&:hover': {
+      textDecoration: "underline",
       color: Colors.green400,
     },
   },

--- a/src/index.css
+++ b/src/index.css
@@ -40,10 +40,6 @@ body {
   padding: 0;
 }
 
-a {
-  color: hwb(128 0% 16%); 
-}
-
 a:focus {
   outline: none;
   box-shadow: none;

--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,10 @@ body {
   padding: 0;
 }
 
+a {
+  color: hwb(128 0% 16%); 
+}
+
 a:focus {
   outline: none;
   box-shadow: none;


### PR DESCRIPTION
Was going through connect and never realized that both `FAQ` and `shop` are hyperlinks on the Checkout page

This PR just adds styling on them so that they're more obvious to users.

Before:
<img width="470" alt="Screenshot 2024-05-16 at 3 18 41 PM" src="https://github.com/commaai/connect/assets/65101411/f24a1f9b-af87-49b2-9306-32208693fc65">

After:
<img width="470" alt="Screenshot 2024-05-16 at 3 18 41 PM" src="https://github.com/commaai/connect/assets/65101411/72326cff-fcfc-4fbc-b235-a60652cdf20f">
