### PR TITLE
Fix routes not loading from useradmin

### DIFF
--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -201,10 +201,10 @@ class DriveVideo extends Component {
   }
 
   syncVideo() {
-    const { dispatch, isBufferingVideo, currentRoute } = this.props;
+    const { dispatch, isBufferingVideo, currentRoute, routes } = this.props;
     if (!currentRoute) {
       dispatch(updateSegments());
-      if (currentRoute && isBufferingVideo) {
+      if (routes && isBufferingVideo) {
         dispatch(bufferVideo(false));
       }
       return;
@@ -317,6 +317,7 @@ const stateToProps = Obstruction({
   offset: 'offset',
   startTime: 'startTime',
   isBufferingVideo: 'isBufferingVideo',
+  routes: 'routes',
   currentRoute: 'currentRoute',
 });
 


### PR DESCRIPTION
This basically sets buffering to false on page load, causing the current offset to be advanced in real time. Once it reaches the route offset boundary it selects that route. This is needed because Route4 start/end times are truncated to seconds but segment times are millisecond precision.

Before, a route at t=1082ms offset wouldn't be selected by a url to t=1000ms

Small revert of https://github.com/commaai/connect/pull/456, instead of altering the route matching from https://github.com/commaai/connect/pull/471