### PR TITLE
[WIP] pause video when leaving tab

### DIFF
--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -11,7 +11,7 @@ import { video as Video } from '@commaai/api';
 import Colors from '../../colors';
 import { ErrorOutline } from '../../icons';
 import { currentOffset } from '../../timeline';
-import { seek, bufferVideo, play, pause } from '../../timeline/playback';
+import { seek, bufferVideo } from '../../timeline/playback';
 import { updateSegments } from '../../timeline/segments';
 
 const VideoOverlay = ({ loading, error }) => {

--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -65,7 +65,6 @@ class DriveVideo extends Component {
     this.onVideoError = this.onVideoError.bind(this);
     this.onVideoResume = this.onVideoResume.bind(this);
     this.syncVideo = debounce(this.syncVideo.bind(this), 200, true);
-    this.onVisibilityChange = this.onVisibilityChange.bind(this);
     this.firstSeek = true;
 
     this.videoPlayer = React.createRef();
@@ -84,7 +83,6 @@ class DriveVideo extends Component {
     this.updateVideoSource({});
     this.syncVideo();
     this.videoSyncIntv = setInterval(this.syncVideo, 500);
-    document.addEventListener('visibilitychange', this.onVisibilityChange);
   }
 
   componentDidUpdate(prevProps) {
@@ -96,18 +94,6 @@ class DriveVideo extends Component {
     if (this.videoSyncIntv) {
       clearTimeout(this.videoSyncIntv);
       this.videoSyncIntv = null;
-    }
-    document.removeEventListener('visibilitychange', this.onVisibilityChange);
-  }
-
-  onVisibilityChange() {
-    const { dispatch, desiredPlaySpeed} = this.props;
-    if (document.visibilityState === 'hidden') {
-      dispatch(pause());
-    } else if (document.visibilityState === 'visible') {
-      console.log('visibility change', desiredPlaySpeed);
-      dispatch(play(desiredPlaySpeed));
-      this.syncVideo();
     }
   }
 

--- a/src/components/DriveVideo/index.jsx
+++ b/src/components/DriveVideo/index.jsx
@@ -11,7 +11,7 @@ import { video as Video } from '@commaai/api';
 import Colors from '../../colors';
 import { ErrorOutline } from '../../icons';
 import { currentOffset } from '../../timeline';
-import { seek, bufferVideo } from '../../timeline/playback';
+import { seek, bufferVideo, play, pause } from '../../timeline/playback';
 import { updateSegments } from '../../timeline/segments';
 
 const VideoOverlay = ({ loading, error }) => {
@@ -65,6 +65,7 @@ class DriveVideo extends Component {
     this.onVideoError = this.onVideoError.bind(this);
     this.onVideoResume = this.onVideoResume.bind(this);
     this.syncVideo = debounce(this.syncVideo.bind(this), 200, true);
+    this.onVisibilityChange = this.onVisibilityChange.bind(this);
     this.firstSeek = true;
 
     this.videoPlayer = React.createRef();
@@ -83,6 +84,7 @@ class DriveVideo extends Component {
     this.updateVideoSource({});
     this.syncVideo();
     this.videoSyncIntv = setInterval(this.syncVideo, 500);
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
   }
 
   componentDidUpdate(prevProps) {
@@ -94,6 +96,18 @@ class DriveVideo extends Component {
     if (this.videoSyncIntv) {
       clearTimeout(this.videoSyncIntv);
       this.videoSyncIntv = null;
+    }
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
+  }
+
+  onVisibilityChange() {
+    const { dispatch, desiredPlaySpeed} = this.props;
+    if (document.visibilityState === 'hidden') {
+      dispatch(pause());
+    } else if (document.visibilityState === 'visible') {
+      console.log('visibility change', desiredPlaySpeed);
+      dispatch(play(desiredPlaySpeed));
+      this.syncVideo();
     }
   }
 

--- a/src/components/TimeDisplay/index.jsx
+++ b/src/components/TimeDisplay/index.jsx
@@ -118,6 +118,7 @@ class TimeDisplay extends Component {
     this.decreaseSpeed = this.decreaseSpeed.bind(this);
     this.jumpBack = this.jumpBack.bind(this);
     this.jumpForward = this.jumpForward.bind(this);
+    this.onVisibilityChange = this.onVisibilityChange.bind(this);
 
     this.state = {
       desiredPlaySpeed: 1,
@@ -128,10 +129,23 @@ class TimeDisplay extends Component {
   componentDidMount() {
     this.mounted = true;
     raf(this.updateTime);
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
   }
 
   componentWillUnmount() {
     this.mounted = false;
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
+  }
+
+  onVisibilityChange() {
+    const { dispatch } = this.props;
+    if (document.visibilityState === 'hidden') {
+      dispatch(pause());
+    } else if (document.visibilityState === 'visible') {
+      const { desiredPlaySpeed } = this.state;
+      let curIndex = timerSteps.indexOf(desiredPlaySpeed);
+      dispatch(play(timerSteps[curIndex]));
+    }
   }
 
   getDisplayTime() {


### PR DESCRIPTION
Fixes #400 

Adds pausing by checking visibility state of TimeDisplay. Pauses when user navigates away and starts playing again when they come back. 