### PR TITLE
Add year to route date when not current year

### DIFF
--- a/src/components/Dashboard/DriveListItem.jsx
+++ b/src/components/Dashboard/DriveListItem.jsx
@@ -89,7 +89,7 @@ const DriveListItem = (props) => {
 
   const small = windowWidth < 580;
   const startTime = dayjs(drive.start_time_utc_millis).format('HH:mm');
-  const startDate = dayjs(drive.start_time_utc_millis).format(small ? 'ddd, MMM D' : 'dddd, MMM D');
+  const startDate = dayjs(drive.start_time_utc_millis).format(small ? 'ddd, MMM D, YYYY' : 'dddd, MMM D, YYYY');
   const endTime = dayjs(drive.end_time_utc_millis).format('HH:mm');
   const duration = formatDriveDuration(drive.duration);
 

--- a/src/components/Dashboard/DriveListItem.jsx
+++ b/src/components/Dashboard/DriveListItem.jsx
@@ -88,8 +88,10 @@ const DriveListItem = (props) => {
   );
 
   const small = windowWidth < 580;
-  const startTime = dayjs(drive.start_time_utc_millis).format('HH:mm');
-  const startDate = dayjs(drive.start_time_utc_millis).format(small ? 'ddd, MMM D, YYYY' : 'dddd, MMM D, YYYY');
+  const dateFormat = small ? 'ddd, MMM D' : 'dddd, MMM D';
+  const startDateObj = dayjs(drive.start_time_utc_millis);
+  const startTime = startDateObj.format('HH:mm');
+  const startDate = startDateObj.format(dayjs().year() === startDateObj.year() ? dateFormat : `${dateFormat}, YYYY`);
   const endTime = dayjs(drive.end_time_utc_millis).format('HH:mm');
   const duration = formatDriveDuration(drive.duration);
 

--- a/src/components/DriveView/index.jsx
+++ b/src/components/DriveView/index.jsx
@@ -42,7 +42,7 @@ class DriveView extends Component {
     // FIXME: end time not always same day as start time
     const start = currentRoute.start_time_utc_millis + zoom.start;
     const startDay = dayjs(start).format('dddd');
-    const startTime = dayjs(start).format('MMM D @ HH:mm');
+    const startTime = dayjs(start).format('MMM D, YYYY @ HH:mm');
     const endTime = dayjs(start + (zoom.end - zoom.start)).format('HH:mm');
 
     return (

--- a/src/components/DriveView/index.jsx
+++ b/src/components/DriveView/index.jsx
@@ -41,8 +41,9 @@ class DriveView extends Component {
 
     // FIXME: end time not always same day as start time
     const start = currentRoute.start_time_utc_millis + zoom.start;
-    const startDay = dayjs(start).format('dddd');
-    const startTime = dayjs(start).format('MMM D, YYYY @ HH:mm');
+    const startDateObj = dayjs(start);
+    const startDay = startDateObj.format('dddd');
+    const startTime = startDateObj.format(`MMM D ${dayjs().year() === startDateObj.year() ? '' : ', YYYY'} @ HH:mm`);
     const endTime = dayjs(start + (zoom.end - zoom.start)).format('HH:mm');
 
     return (

--- a/src/components/DriveView/index.jsx
+++ b/src/components/DriveView/index.jsx
@@ -43,7 +43,7 @@ class DriveView extends Component {
     const start = currentRoute.start_time_utc_millis + zoom.start;
     const startDateObj = dayjs(start);
     const startDay = startDateObj.format('dddd');
-    const startTime = startDateObj.format(`MMM D ${dayjs().year() === startDateObj.year() ? '' : ', YYYY'} @ HH:mm`);
+    const startTime = startDateObj.format(`MMM D${dayjs().year() === startDateObj.year() ? '' : ', YYYY'} @ HH:mm`);
     const endTime = dayjs(start + (zoom.end - zoom.start)).format('HH:mm');
 
     return (


### PR DESCRIPTION
This fixes #507. This includes the following changes:

* in the drives list, the year will be shown if it's not the current year.
* in the drive view, the year will be shown regardless