### PR TITLE
Add tweet button to drives

### DIFF
--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -239,6 +239,7 @@ class Media extends Component {
     this.copySegmentName = this.copySegmentName.bind(this);
     this.openInUseradmin = this.openInUseradmin.bind(this);
     this.shareCurrentRoute = this.shareCurrentRoute.bind(this);
+    this.tweetRoute = this.tweetRoute.bind(this);
     this.uploadFile = this.uploadFile.bind(this);
     this.uploadFilesAll = this.uploadFilesAll.bind(this);
     this.getUploadStats = this.getUploadStats.bind(this);
@@ -330,6 +331,23 @@ class Media extends Component {
       console.error(err);
       Sentry.captureException(err, { fingerprint: 'media_navigator_share' });
     }
+  }
+
+  tweetRoute() {
+    const { currentRoute } = this.props;
+
+    let percentage = 0, engagements = 0;
+    currentRoute.events
+      .filter((event) => event.data && event.data.end_route_offset_millis)
+      .forEach(event => {
+        if(event.type === 'engage') {
+          percentage += parseInt(((event.data.end_route_offset_millis - event.route_offset_millis) / currentRoute.duration) * 100);
+          engagements++;
+        }
+      })
+    
+    const post = `I went on a pretty chill drive ${currentRoute.startLocation?.place ? `from ${currentRoute.startLocation.place}` : ''}${currentRoute.endLocation?.place ? ` to ${currentRoute.endLocation.place}` : ''} in my ${currentRoute.platform.replace("_", ' ').toLowerCase()} as openpilot drove ~${percentage}% of the route with less than ${engagements+1} disengagements!\nCheck out the full drive on comma connect at ${window.location.href}.`; 
+    window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(post)}`, '_blank').focus();
   }
 
   async uploadFile(type) {
@@ -741,6 +759,10 @@ class Media extends Component {
             <ShareIcon />
           </MenuItem>
           )}
+          <MenuItem onClick={ this.tweetRoute } className={ classes.shareButton }>
+            Post on X
+            <ShareIcon />
+          </MenuItem>
           <Divider />
           <MenuItem onClick={ this.openInUseradmin }>
             View in useradmin

--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -343,7 +343,7 @@ class Media extends Component {
       .forEach(event => {
         if(event.type === 'engage') {
           percentage += parseInt(((event.data.end_route_offset_millis - event.route_offset_millis) / currentRoute.duration) * 100);
-          engagements++;
+          engagements += 1;
         }
       })
     

--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -8,6 +8,7 @@ import { withStyles, Divider, Typography, Menu, MenuItem, CircularProgress, Butt
 import WarningIcon from '@material-ui/icons/Warning';
 import ContentCopyIcon from '@material-ui/icons/ContentCopy';
 import ShareIcon from '@material-ui/icons/Share';
+import XIcon from './XIcon';
 
 import { drives as Drives } from '@commaai/api';
 
@@ -761,7 +762,7 @@ class Media extends Component {
           )}
           <MenuItem onClick={ this.tweetRoute } className={ classes.shareButton }>
             Post on X
-            <ShareIcon />
+            <XIcon />
           </MenuItem>
           <Divider />
           <MenuItem onClick={ this.openInUseradmin }>

--- a/src/components/DriveView/XIcon.jsx
+++ b/src/components/DriveView/XIcon.jsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import React, { Component } from 'react';
 import SvgIcon from '@material-ui/core/SvgIcon';
 
-function XIcon(props) {
-    return (
-        <SvgIcon {...props}>
+class XIcon extends Component {
+    render() {
+        return <SvgIcon {...this.props}>
             <g>
                 <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
             </g>
         </SvgIcon>
-    );
+    }
 }
 
 export default XIcon;

--- a/src/components/DriveView/XIcon.jsx
+++ b/src/components/DriveView/XIcon.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+function XIcon(props) {
+    return (
+        <SvgIcon {...props}>
+            <g>
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+            </g>
+        </SvgIcon>
+    );
+}
+
+export default XIcon;


### PR DESCRIPTION
Fixes #84. This PR adds a **Post to X** option to the drive view component that lets the user post a drive to twitter/X with the following message:

> I went on a pretty chill drive from `place_A` to `place_B` in my `platform` as openpilot drove ~`x`% of the route with less than `y` disengagements! Check out the drive at `url`.

where:
    * `place_A` is the place from `startLocation`
    * `place_B` is the place from `endLocation`
    * `platform` is a formatted version of `platform`
    * `x` is the sum of `((event.data.end_route_offset_millis - event.route_offset_millis) / currentRoute.duration) * 100` for all `engage` events
    * `y` is the number of `engage` events plus one.
    * `url` is the current URL

This uses twitter's web intent to write the tweet. As of now, it doesn't seem like images are supported. This option can be found under the **Share this route** option in **More Info**.