### PR TITLE
DriveMap: fixed high CPU usage during idling

### DIFF
--- a/src/components/DriveMap/index.jsx
+++ b/src/components/DriveMap/index.jsx
@@ -36,6 +36,7 @@ class DriveMap extends Component {
     this.shouldFlyTo = false;
     this.isInteracting = false;
     this.isInteractingTimeout = null;
+    this.lastMapPos = [0, 0];
   }
 
   componentDidMount() {
@@ -99,7 +100,8 @@ class DriveMap extends Component {
     if (markerSource) {
       if (this.props.currentRoute && this.props.currentRoute.driveCoords) {
         const pos = this.posAtOffset(currentOffset());
-        if (pos) {
+        if (pos && pos.every((coordinate, index) => coordinate != this.lastMapPos[index])) {
+          this.lastMapPos = pos;
           markerSource.setData({
             type: 'Point',
             coordinates: pos,

--- a/src/components/DriveMap/index.jsx
+++ b/src/components/DriveMap/index.jsx
@@ -100,7 +100,7 @@ class DriveMap extends Component {
     if (markerSource) {
       if (this.props.currentRoute && this.props.currentRoute.driveCoords) {
         const pos = this.posAtOffset(currentOffset());
-        if (pos && pos.every((coordinate, index) => coordinate != this.lastMapPos[index])) {
+        if (pos && pos.some((coordinate, index) => coordinate != this.lastMapPos[index])) {
           this.lastMapPos = pos;
           markerSource.setData({
             type: 'Point',


### PR DESCRIPTION
Fixes #378. The CPU usage was due to the following lines of code being executed unnecessarily within the map component's `updateMarkerPos()` method:

```javascript
updateMarkerPos() {
    // ..
        markerSource.setData({
            type: 'Point',
            coordinates: pos,
          });
          if (!this.isInteracting) {
            this.moveViewportTo(pos);
          }
    // ...
}
```

I noticed this when I profiled the component with react's [`<Profiler />`](https://legacy.reactjs.org/docs/profiler.html).  The map was constantly re-rendering even with the video paused. Logically, the only reason that map would want to re-render all the time would be to update the marker position according to the video. But, this was happening when the video was paused as well.

In order to update the marker position in real time, the map consumes CPU. This is fine, but the bottleneck arises when the map keeps updating the marker even while the video is idle. To fix this, I simply introduced a check. If the last position of the marker hasn't changed, then don't re-render it. This has fixed the high CPU usage when the video is paused or in other words, the page is idle.