### PR TITLE
Use max of route's length and limit to fetch next routes

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -103,15 +103,16 @@ export function checkRoutesData() {
 
 export function checkLastRoutesData() {
   return (dispatch, getState) => {
-    const limit = getState().limit
-    const routes = getState().routes
+    const routes = getState().routes || []
+    const limit = Math.max(getState().limit, routes.length)
+
 
     // if current routes are fewer than limit, that means the last fetch already fetched all the routes
-    if (routes && routes.length < limit) {
+    if (routes.length < limit) {
       return
     }
 
-    console.log(`fetching ${limit +LIMIT_INCREMENT } routes`)
+    console.debug(`fetching ${limit +LIMIT_INCREMENT } routes`)
     dispatch({
       type: Types.ACTION_UPDATE_ROUTE_LIMIT,
       limit: limit + LIMIT_INCREMENT,


### PR DESCRIPTION
Fix #532.

When clicking on the same device from a route,  the page already fetched the first page of routes, but the fetch limit` gets reset;
So for next page fetch, we will check the max value of current routes and limit