### PR TITLE
support multiple possible file names

### DIFF
--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -22,7 +22,6 @@ let openRequests = 0;
 function pathToFileName(dongleId, path) {
   const [seg, fileType] = path.split('/');
   const type = Object.entries(FILE_NAMES).find((e) => e[1].includes(fileType))[0];
-  console.log('pathToFileName', path, type)
   return `${dongleId}|${seg}/${type}`;
 }
 
@@ -98,7 +97,6 @@ export function fetchFiles(routeName, nocache = false) {
     let files;
     try {
       files = await Raw.getRouteFiles(routeName, nocache);
-      console.log('files', files)
     } catch (err) {
       console.error(err);
       Sentry.captureException(err, { fingerprint: 'action_files_fetch_files' });
@@ -119,7 +117,6 @@ export function fetchFiles(routeName, nocache = false) {
         };
         return state;
       }, {});
-    console.log('urls', urls)
 
     dispatch({
       type: Types.ACTION_FILES_URLS,
@@ -310,7 +307,6 @@ export function doUpload(dongleId, paths, urls) {
 
 export function fetchAthenaQueue(dongleId) {
   return async (dispatch) => {
-    console.log('fetchAthenaQueue')
     let queue;
     try {
       queue = await Devices.getAthenaQueue(dongleId);
@@ -328,12 +324,10 @@ export function fetchAthenaQueue(dongleId) {
 
       if (q.method === 'uploadFileToUrl') {
         const fileName = pathToFileName(dongleId, q.params[0]);
-        console.log('uploadFileToUrl', q.params[0], fileName)
         newUploading[fileName] = { progress: 0, current: false };
       } else if (q.method === 'uploadFilesToUrls') {
         for (const { fn } of q.params.files_data) {
           const fileName = pathToFileName(dongleId, fn);
-          console.log(['uploadFilesToUrls', fn, fileName])
           newUploading[fileName] = { progress: 0, current: false };
         }
       }

--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -210,7 +210,7 @@ export function fetchUploadQueue(dongleId) {
   };
 }
 
-export function doUpload(dongleId, fileNames, paths, urls) {
+export function doUpload(dongleId, paths, urls) {
   return async (dispatch, getState) => {
     const { device } = getState();
     let loopedUploads = !deviceVersionAtLeast(device, '0.8.13');
@@ -230,12 +230,13 @@ export function doUpload(dongleId, fileNames, paths, urls) {
         expiry: Math.floor(Date.now() / 1000) + (86400 * 7),
       };
       const resp = await athenaCall(dongleId, payload, 'action_files_athena_uploads');
+      console.log('resp', resp)
       if (resp && resp.error && resp.error.code === -32000
         && resp.error.data.message === 'too many values to unpack (expected 3)') {
         loopedUploads = true;
       } else if (!resp || resp.error) {
-        const newUploading = fileNames.reduce((state, fn) => {
-          state[fn] = {};
+        const newUploading = paths.reduce((state, path) => {
+          state[pathToFileName(dongleId, path)] = {};
           return state;
         }, {});
         dispatch(updateDeviceOnline(dongleId, Math.floor(Date.now() / 1000)));
@@ -243,28 +244,52 @@ export function doUpload(dongleId, fileNames, paths, urls) {
       } else if (resp.offline) {
         dispatch(updateDeviceOnline(dongleId, 0));
       } else if (resp.result === 'Device offline, message queued') {
-        const newUploading = fileNames.reduce((state, fn) => {
-          state[fn] = { progress: 0, current: false };
+        const newUploading = paths.reduce((state, path) => {
+          state[pathToFileName(dongleId, path)] = { progress: 0, current: false };
           return state;
         }, {});
         dispatch(updateFiles(newUploading));
       } else if (resp.result) {
         if (resp.result.failed) {
-          const uploading = resp.result.failed
-            .filter((path) => paths.indexOf(path) > -1)
-            .reduce((state, path) => {
-              const fn = fileNames[paths.indexOf(path)];
-              state[fn] = { notFound: true };
-              return state;
-            }, {});
-          dispatch(updateFiles(uploading));
+
+          // only if all file names for a segment file type failed
+          let failedFiltered = [];
+          for (let f of resp.result.failed) {
+            console.log('resp failed', f)
+            let failedCnt = resp.result.failed.filter((p) => pathToFileName(dongleId, p) === pathToFileName(dongleId, f)).length;
+            let requestedCnt = paths.filter((p) => pathToFileName(dongleId, p) === pathToFileName(dongleId, f)).length;
+            if (failedCnt >= requestedCnt) {
+              failedFiltered.push(f);
+            }
+            console.log('resp failed_type_cnt', failedCnt, 'requested_type_cnt', requestedCnt)
+          }
+
+          console.log('resp paths', paths)
+          console.log('resp failed', resp.result.failed.map((f) => f.split('--').pop()))
+          // let failed = resp.result.failed.map((f) => pathToFileName(dongleId, f));
+          // let requested = new Set(paths.map((f) => pathToFileName(dongleId, f)));
+          // let diff = failed.filter((f) => requested.has(f));
+          // // console.log(['resp custom failed', failed, requested, diff])
+
+          if (failedFiltered) {
+            // console.log('resp failed', resp_result_failed, paths)
+
+            const uploading = failedFiltered
+              .reduce((state, path) => {
+                const fn = pathToFileName(dongleId, path);
+                state[fn] = { notFound: true };
+                return state;
+              }, {});
+
+            dispatch(updateFiles(uploading));
+          }
         }
         dispatch(fetchUploadQueue(dongleId));
       }
     }
 
     if (loopedUploads) {
-      for (let i = 0; i < fileNames.length; i++) {
+      for (let i = 0; i < paths.length; i++) {
         const payload = {
           id: 0,
           jsonrpc: '2.0',
@@ -276,18 +301,18 @@ export function doUpload(dongleId, fileNames, paths, urls) {
         const resp = await athenaCall(dongleId, payload, 'files_actions_athena_upload');
         if (!resp || resp.error) {
           const uploading = {};
-          uploading[fileNames[i]] = {};
+          uploading[pathToFileName(dongleId, paths[i])] = {};
           dispatch(updateDeviceOnline(dongleId, Math.floor(Date.now() / 1000)));
           dispatch(updateFiles(uploading));
         } else if (resp.offline) {
           dispatch(updateDeviceOnline(dongleId, 0));
         } else if (resp.result === 'Device offline, message queued') {
           const uploading = {};
-          uploading[fileNames[i]] = { progress: 0, current: false };
+          uploading[pathToFileName(dongleId, paths[i])] = { progress: 0, current: false };
           dispatch(updateFiles(uploading));
         } else if (resp.result === 404 || resp?.result?.failed?.[0] === paths[i]) {
           const uploading = {};
-          uploading[fileNames[i]] = { notFound: true };
+          uploading[pathToFileName(dongleId, paths[i])] = { notFound: true };
           dispatch(updateFiles(uploading));
         } else if (resp.result) {
           dispatch(fetchUploadQueue(dongleId));

--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -221,6 +221,7 @@ export function doUpload(dongleId, fileNames, paths, urls) {
         headers: { 'x-ms-blob-type': 'BlockBlob' },
         allow_cellular: false,
       }));
+      console.log('files_data', filesData)
       const payload = {
         id: 0,
         jsonrpc: '2.0',

--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -245,27 +245,26 @@ export function doUpload(dongleId, paths, urls) {
         }, {});
         dispatch(updateFiles(newUploading));
       } else if (resp.result) {
-        if (resp.result.failed) {
+        let failed = resp.result.failed || [];
 
-          // only if all file names for a segment file type failed
-          let failedFiltered = [];
-          for (let f of resp.result.failed) {
-            let failedCnt = resp.result.failed.filter((p) => pathToFileName(dongleId, p) === pathToFileName(dongleId, f)).length;
-            let requestedCnt = paths.filter((p) => pathToFileName(dongleId, p) === pathToFileName(dongleId, f)).length;
-            if (failedCnt >= requestedCnt) {
-              failedFiltered.push(f);
-            }
+        // only if all file names for a segment file type failed
+        let failedFiltered = [];
+        for (let f of failed) {
+          let failedCnt = failed.filter((p) => pathToFileName(dongleId, p) === pathToFileName(dongleId, f)).length;
+          let requestedCnt = paths.filter((p) => pathToFileName(dongleId, p) === pathToFileName(dongleId, f)).length;
+          if (failedCnt >= requestedCnt) {
+            failedFiltered.push(f);
           }
+        }
 
-          if (failedFiltered) {
-            const uploading = failedFiltered
-              .reduce((state, path) => {
-                const fn = pathToFileName(dongleId, path);
-                state[fn] = { notFound: true };
-                return state;
-              }, {});
-            dispatch(updateFiles(uploading));
-          }
+        if (failedFiltered) {
+          const uploading = failedFiltered
+            .reduce((state, path) => {
+              const fn = pathToFileName(dongleId, path);
+              state[fn] = { notFound: true };
+              return state;
+            }, {});
+          dispatch(updateFiles(uploading));
         }
         dispatch(fetchUploadQueue(dongleId));
       }

--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -10,7 +10,7 @@ export const FILE_NAMES = {
   cameras: ['fcamera.hevc'],
   dcameras: ['dcamera.hevc'],
   ecameras: ['ecamera.hevc'],
-  qlogs: ['qlog.bz2'],
+  qlogs: ['qlog.bz2', 'qlog.zst'],
   logs: ['rlog.bz2', 'rlog.zst'],
 };
 const MAX_OPEN_REQUESTS = 15;

--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -249,7 +249,7 @@ export function doUpload(dongleId, paths, urls) {
 
         // only if all file names for a segment file type failed
         let failedFiltered = [];
-        for (let f of failed) {
+        for (const f of failed) {
           let failedCnt = failed.filter((p) => pathToFileName(dongleId, p) === pathToFileName(dongleId, f)).length;
           let requestedCnt = paths.filter((p) => pathToFileName(dongleId, p) === pathToFileName(dongleId, f)).length;
           if (failedCnt >= requestedCnt) {

--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -355,7 +355,7 @@ class Media extends Component {
       console.log('123. fileNames', fileNames)
       console.log('123. paths', paths)
       console.log('123. urls', urls)
-      this.props.dispatch(doUpload(dongleId, fileNames, paths, urls));
+      this.props.dispatch(doUpload(dongleId, paths, urls));
     }
 
   }
@@ -403,7 +403,7 @@ class Media extends Component {
 
     const urls = await fetchUploadUrls(dongleId, paths);
     if (urls) {
-      this.props.dispatch(doUpload(dongleId, Object.keys(uploading), paths, urls));
+      this.props.dispatch(doUpload(dongleId, paths, urls));
     }
   }
 
@@ -801,6 +801,7 @@ class Media extends Component {
   renderUploadMenuItem([file, name, type]) {
     const { device, classes, files, profile } = this.props;
     const { windowWidth } = this.state;
+    console.log('file', file, 'name', name, 'type', type)
 
     const canUpload = device.is_owner || (profile && profile.superuser);
     const uploadButtonWidth = windowWidth < 425 ? 80 : 120;

--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -334,16 +334,19 @@ class Media extends Component {
     }));
 
     const routeNoDongleId = currentRoute.fullname.split('|')[1];
-    const path = `${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${FILE_NAMES[type]}`;
-    const fileName = `${dongleId}|${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${type}`;
+    // request any possible file names
+    for (let fn of FILE_NAMES[type]){
+      const path = `${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${fn}`;
+      const fileName = `${dongleId}|${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${type}`;
 
-    const uploading = {};
-    uploading[fileName] = { requested: true };
-    this.props.dispatch(updateFiles(uploading));
+      const uploading = {};
+      uploading[fileName] = { requested: true };
+      this.props.dispatch(updateFiles(uploading));
 
-    const urls = await fetchUploadUrls(dongleId, [path]);
-    if (urls) {
-      this.props.dispatch(doUpload(dongleId, [fileName], [path], urls));
+      const urls = await fetchUploadUrls(dongleId, [path]);
+      if (urls) {
+        this.props.dispatch(doUpload(dongleId, [fileName], [path], urls));
+      }
     }
   }
 
@@ -376,10 +379,17 @@ class Media extends Component {
     }
     this.props.dispatch(updateFiles(uploading));
 
-    const paths = Object.keys(uploading).map((fileName) => {
+    // const paths = Object.keys(uploading).map((fileName) => {
+    //   const [seg, type] = fileName.split('/');
+    //   console.log('returning', `${seg.split('|')[1]}/${FILE_NAMES[type]}`)
+    //   return `${seg.split('|')[1]}/${FILE_NAMES[type]}`;
+    // });
+
+    const paths = Object.keys(uploading).flatMap((fileName) => {
       const [seg, type] = fileName.split('/');
-      return `${seg.split('|')[1]}/${FILE_NAMES[type]}`;
+      return FILE_NAMES[type].map(file => `${seg.split('|')[1]}/${file}`);
     });
+    console.log('paths v2', paths)
 
     const urls = await fetchUploadUrls(dongleId, paths);
     if (urls) {

--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -344,7 +344,7 @@ class Media extends Component {
     let url_promises = [];
 
     // request all possible file names
-    for (let fn of FILE_NAMES[type]) {
+    for (const fn of FILE_NAMES[type]) {
       const path = `${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${fn}`;
       paths.push(path);
       url_promises.push(fetchUploadUrls(dongleId, [path]).then(urls => urls[0]));

--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -334,8 +334,8 @@ class Media extends Component {
     }));
 
     const routeNoDongleId = currentRoute.fullname.split('|')[1];
-
     const fileName = `${dongleId}|${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${type}`;
+
     const uploading = {};
     uploading[fileName] = { requested: true };
     this.props.dispatch(updateFiles(uploading));
@@ -344,9 +344,10 @@ class Media extends Component {
     let url_promises = [];
 
     // request all possible file names
-    for (let fn of FILE_NAMES[type]){
-      paths.push(`${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${fn}`);
-      url_promises.push(fetchUploadUrls(dongleId, [paths[paths.length - 1]]).then(urls => urls[0]));
+    for (let fn of FILE_NAMES[type]) {
+      const path = `${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${fn}`;
+      paths.push(path);
+      url_promises.push(fetchUploadUrls(dongleId, [path]).then(urls => urls[0]));
     }
 
     const urls = await Promise.all(url_promises);

--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -351,13 +351,8 @@ class Media extends Component {
 
     const urls = await Promise.all(url_promises);
     if (urls) {
-      let fileNames = Array(paths.length).fill(fileName);
-      console.log('123. fileNames', fileNames)
-      console.log('123. paths', paths)
-      console.log('123. urls', urls)
       this.props.dispatch(doUpload(dongleId, paths, urls));
     }
-
   }
 
   async uploadFilesAll(types) {
@@ -389,17 +384,10 @@ class Media extends Component {
     }
     this.props.dispatch(updateFiles(uploading));
 
-    // const paths = Object.keys(uploading).map((fileName) => {
-    //   const [seg, type] = fileName.split('/');
-    //   console.log('returning', `${seg.split('|')[1]}/${FILE_NAMES[type]}`)
-    //   return `${seg.split('|')[1]}/${FILE_NAMES[type]}`;
-    // });
-
     const paths = Object.keys(uploading).flatMap((fileName) => {
       const [seg, type] = fileName.split('/');
       return FILE_NAMES[type].map(file => `${seg.split('|')[1]}/${file}`);
     });
-    console.log('paths v2', paths)
 
     const urls = await fetchUploadUrls(dongleId, paths);
     if (urls) {
@@ -801,7 +789,6 @@ class Media extends Component {
   renderUploadMenuItem([file, name, type]) {
     const { device, classes, files, profile } = this.props;
     const { windowWidth } = this.state;
-    console.log('file', file, 'name', name, 'type', type)
 
     const canUpload = device.is_owner || (profile && profile.superuser);
     const uploadButtonWidth = windowWidth < 425 ? 80 : 120;

--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -334,20 +334,39 @@ class Media extends Component {
     }));
 
     const routeNoDongleId = currentRoute.fullname.split('|')[1];
+
+    let paths = [];
+    let fileNames = [];
+    let url_promises = [];
+
     // request any possible file names
     for (let fn of FILE_NAMES[type]){
       const path = `${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${fn}`;
       const fileName = `${dongleId}|${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${type}`;
 
+      paths.push(path);
+      fileNames.push(fileName);
+
       const uploading = {};
       uploading[fileName] = { requested: true };
       this.props.dispatch(updateFiles(uploading));
 
-      const urls = await fetchUploadUrls(dongleId, [path]);
-      if (urls) {
-        this.props.dispatch(doUpload(dongleId, [fileName], [path], urls));
-      }
+      url_promises.push(fetchUploadUrls(dongleId, [path]));
+
+      // const urls = await fetchUploadUrls(dongleId, [path]);
+      // if (urls) {
+      //   this.props.dispatch(doUpload(dongleId, [fileName], [path], urls));
+      // }
     }
+
+    const urls = (await Promise.all(url_promises)).map((_urls) => _urls[0]);
+    if (urls) {
+      console.log('123. fileNames', fileNames)
+      console.log('123. paths', paths)
+      console.log('123. urls', urls)
+      this.props.dispatch(doUpload(dongleId, fileNames, paths, urls));
+    }
+
   }
 
   async uploadFilesAll(types) {

--- a/src/components/DriveView/Media.jsx
+++ b/src/components/DriveView/Media.jsx
@@ -335,32 +335,23 @@ class Media extends Component {
 
     const routeNoDongleId = currentRoute.fullname.split('|')[1];
 
+    const fileName = `${dongleId}|${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${type}`;
+    const uploading = {};
+    uploading[fileName] = { requested: true };
+    this.props.dispatch(updateFiles(uploading));
+
     let paths = [];
-    let fileNames = [];
     let url_promises = [];
 
-    // request any possible file names
+    // request all possible file names
     for (let fn of FILE_NAMES[type]){
-      const path = `${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${fn}`;
-      const fileName = `${dongleId}|${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${type}`;
-
-      paths.push(path);
-      fileNames.push(fileName);
-
-      const uploading = {};
-      uploading[fileName] = { requested: true };
-      this.props.dispatch(updateFiles(uploading));
-
-      url_promises.push(fetchUploadUrls(dongleId, [path]));
-
-      // const urls = await fetchUploadUrls(dongleId, [path]);
-      // if (urls) {
-      //   this.props.dispatch(doUpload(dongleId, [fileName], [path], urls));
-      // }
+      paths.push(`${routeNoDongleId}--${getSegmentNumber(currentRoute)}/${fn}`);
+      url_promises.push(fetchUploadUrls(dongleId, [paths[paths.length - 1]]).then(urls => urls[0]));
     }
 
-    const urls = (await Promise.all(url_promises)).map((_urls) => _urls[0]);
+    const urls = await Promise.all(url_promises);
     if (urls) {
+      let fileNames = Array(paths.length).fill(fileName);
       console.log('123. fileNames', fileNames)
       console.log('123. paths', paths)
       console.log('123. urls', urls)

--- a/src/components/Files/UploadQueue.jsx
+++ b/src/components/Files/UploadQueue.jsx
@@ -238,7 +238,7 @@ class UploadQueue extends Component {
                               </div>
                             </td>
                             <td className={ classes.uploadCell } style={ cellStyle }>
-                              { FILE_NAMES[type].split('.')[0].substring(0, logNameLength) }
+                              { FILE_NAMES[type][0].split('.')[0].substring(0, logNameLength) }
                             </td>
                             { upload.current
                               ? (


### PR DESCRIPTION
working version of https://github.com/commaai/connect/pull/542

generically allows any list of file names per type by making multiple upload requests

- [x] the failed request comes back and temporarily shows "not found" on the button
  - we can potentially wait for both/all to come back.
  - or add new urls param to the athena upload endpoint, but that requires more changes to request file types instead of file names

~We'll take the first naive approach to get this shipped ASAP, then properly fix once we drop file extensions altogether (hopefully soon after).~

We instead use one `doUpload` call with multiple file paths and check the `failed` list that returns. If not all file paths for a segment fail, no fail.