### PR TITLE
Fix: Handle routes with no time

### DIFF
--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -1,21 +1,21 @@
-import { Suspense, type VoidComponent } from "solid-js";
-import dayjs from "dayjs";
+import { Suspense, type VoidComponent } from 'solid-js'
+import dayjs from 'dayjs'
 
-import Avatar from "~/components/material/Avatar";
-import Card, { CardContent, CardHeader } from "~/components/material/Card";
-import Icon from "~/components/material/Icon";
-import RouteStaticMap from "~/components/RouteStaticMap";
-import RouteStatistics from "~/components/RouteStatistics";
+import Avatar from '~/components/material/Avatar'
+import Card, { CardContent, CardHeader } from '~/components/material/Card'
+import Icon from '~/components/material/Icon'
+import RouteStaticMap from '~/components/RouteStaticMap'
+import RouteStatistics from '~/components/RouteStatistics'
 
-import type { RouteSegments } from "~/types";
+import type { RouteSegments } from '~/types'
 
 const RouteHeader = (props: { route: RouteSegments }) => {
-  const startTime = () => dayjs(props.route.start_time_utc_millis);
-  const endTime = () => dayjs(props.route.end_time_utc_millis);
+  const startTime = () => dayjs(props.route.start_time_utc_millis)
+  const endTime = () => dayjs(props.route.end_time_utc_millis)
 
-  const headline = () => startTime().format("ddd, MMM D, YYYY");
+  const headline = () => startTime().format('ddd, MMM D, YYYY')
   const subhead = () =>
-    `${startTime().format("h:mm A")} to ${endTime().format("h:mm A")}`;
+    `${startTime().format('h:mm A')} to ${endTime().format('h:mm A')}`
 
   return (
     <>
@@ -35,8 +35,8 @@ const RouteHeader = (props: { route: RouteSegments }) => {
         <div class="flex h-[10px] items-center gap-4 px-4 py-3" />
       )}
     </>
-  );
-};
+  )
+}
 
 interface RouteCardProps {
   route: RouteSegments;
@@ -59,7 +59,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
         <RouteStatistics route={props.route} />
       </CardContent>
     </Card>
-  );
-};
+  )
+}
 
-export default RouteCard;
+export default RouteCard

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -1,36 +1,45 @@
-import { Suspense, type VoidComponent } from 'solid-js'
-import dayjs from 'dayjs'
+import { Suspense, type VoidComponent } from "solid-js";
+import dayjs from "dayjs";
 
-import Avatar from '~/components/material/Avatar'
-import Card, { CardContent, CardHeader } from '~/components/material/Card'
-import Icon from '~/components/material/Icon'
-import RouteStaticMap from '~/components/RouteStaticMap'
-import RouteStatistics from '~/components/RouteStatistics'
+import Avatar from "~/components/material/Avatar";
+import Card, { CardContent, CardHeader } from "~/components/material/Card";
+import Icon from "~/components/material/Icon";
+import RouteStaticMap from "~/components/RouteStaticMap";
+import RouteStatistics from "~/components/RouteStatistics";
 
-import type { RouteSegments } from '~/types'
+import type { RouteSegments } from "~/types";
 
 const RouteHeader = (props: { route: RouteSegments }) => {
-  const startTime = () => dayjs(props.route.start_time_utc_millis)
-  const endTime = () => dayjs(props.route.end_time_utc_millis)
+  const startTime = () => dayjs(props.route.start_time_utc_millis);
+  const endTime = () => dayjs(props.route.end_time_utc_millis);
 
-  const headline = () => startTime().format('ddd, MMM D, YYYY')
-  const subhead = () => `${startTime().format('h:mm A')} to ${endTime().format('h:mm A')}`
+  const headline = () => startTime().format("ddd, MMM D, YYYY");
+  const subhead = () =>
+    `${startTime().format("h:mm A")} to ${endTime().format("h:mm A")}`;
 
   return (
-    <CardHeader
-      headline={headline()}
-      subhead={subhead()}
-      leading={
-        <Avatar>
-          <Icon>directions_car</Icon>
-        </Avatar>
-      }
-    />
-  )
-}
+    <>
+      {props.route.start_time_utc_millis ? (
+        <CardHeader
+          headline={headline()}
+          subhead={subhead()}
+          leading={
+            <>
+              <Avatar>
+                <Icon>directions_car</Icon>
+              </Avatar>
+            </>
+          }
+        />
+      ) : (
+        <div class="flex h-[10px] items-center gap-4 px-4 py-3" />
+      )}
+    </>
+  );
+};
 
 interface RouteCardProps {
-  route: RouteSegments
+  route: RouteSegments;
 }
 
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
@@ -50,7 +59,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
         <RouteStatistics route={props.route} />
       </CardContent>
     </Card>
-  )
-}
+  );
+};
 
-export default RouteCard
+export default RouteCard;

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -5,70 +5,70 @@ import {
   createSignal,
   For,
   Suspense,
-} from "solid-js";
-import type { VoidComponent } from "solid-js";
-import clsx from "clsx";
+} from 'solid-js'
+import type { VoidComponent } from 'solid-js'
+import clsx from 'clsx'
 
-import type { RouteSegments } from "~/types";
+import type { RouteSegments } from '~/types'
 
-import RouteCard from "~/components/RouteCard";
-import { fetcher } from "~/api";
-import Button from "~/components/material/Button";
+import RouteCard from '~/components/RouteCard'
+import { fetcher } from '~/api'
+import Button from '~/components/material/Button'
 
-const PAGE_SIZE = 3;
+const PAGE_SIZE = 3
 
 type RouteListProps = {
   class?: string;
   dongleId: string;
-};
+}
 
-const pages: Promise<RouteSegments[]>[] = [];
+const pages: Promise<RouteSegments[]>[] = []
 
 const RouteList: VoidComponent<RouteListProps> = (props) => {
   const endpoint = () =>
-    `/v1/devices/${props.dongleId}/routes_segments?limit=${PAGE_SIZE}`;
+    `/v1/devices/${props.dongleId}/routes_segments?limit=${PAGE_SIZE}`
   const getKey = (previousPageData?: RouteSegments[]): string | undefined => {
-    if (!previousPageData) return endpoint();
-    if (previousPageData.length === 0) return undefined;
-    const lastSegmentEndTime = previousPageData.at(-1)!.end_time_utc_millis;
-    return `${endpoint()}&end=${lastSegmentEndTime - 1}`;
-  };
+    if (!previousPageData) return endpoint()
+    if (previousPageData.length === 0) return undefined
+    const lastSegmentEndTime = previousPageData.at(-1)!.end_time_utc_millis
+    return `${endpoint()}&end=${lastSegmentEndTime - 1}`
+  }
   const getPage = (page: number): Promise<RouteSegments[]> => {
     if (!pages[page]) {
       // eslint-disable-next-line no-async-promise-executor
       pages[page] = new Promise(async (resolve) => {
-        const previousPageData = page > 0 ? await getPage(page - 1) : undefined;
-        const key = getKey(previousPageData);
-        resolve(key ? fetcher<RouteSegments[]>(key) : []);
-      });
+        const previousPageData = page > 0 ? await getPage(page - 1) : undefined
+        const key = getKey(previousPageData)
+        resolve(key ? fetcher<RouteSegments[]>(key) : [])
+      })
     }
-    return pages[page];
-  };
+    return pages[page]
+  }
 
   createEffect(() => {
     if (props.dongleId) {
-      pages.length = 0;
-      setSize(1);
+      pages.length = 0
+      setSize(1)
     }
-  });
+  })
 
-  const [size, setSize] = createSignal(1);
-  const onLoadMore = () => setSize(size() + 1);
-  const pageNumbers = () => Array.from(Array(size()).keys());
+  const [size, setSize] = createSignal(1)
+  const onLoadMore = () => setSize(size() + 1)
+  const pageNumbers = () => Array.from(Array(size()).keys())
   const sortByCreateTime = (array: RouteSegments[]) => {
-    return array.sort((a, b) => b.create_time - a.create_time);
-  };
+    return array.sort((a, b) => b.create_time - a.create_time)
+  }
 
   return (
     <div
       class={clsx(
-        "flex w-full flex-col justify-items-stretch gap-4",
+        'flex w-full flex-col justify-items-stretch gap-4',
         props.class,
       )}
     >
       <For each={pageNumbers()}>
         {(i) => {
-          const [routes] = createResource(() => i, getPage);
+          const [routes] = createResource(() => i, getPage)
           return (
             <Suspense
               fallback={
@@ -85,14 +85,14 @@ const RouteList: VoidComponent<RouteListProps> = (props) => {
                 </For>
               )}
             </Suspense>
-          );
+          )
         }}
       </For>
       <div class="flex justify-center">
         <Button onClick={onLoadMore}>Load more</Button>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default RouteList;
+export default RouteList

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -5,66 +5,70 @@ import {
   createSignal,
   For,
   Suspense,
-} from 'solid-js'
-import type { VoidComponent } from 'solid-js'
-import clsx from 'clsx'
+} from "solid-js";
+import type { VoidComponent } from "solid-js";
+import clsx from "clsx";
 
-import type { RouteSegments } from '~/types'
+import type { RouteSegments } from "~/types";
 
-import RouteCard from '~/components/RouteCard'
-import { fetcher } from '~/api'
-import Button from '~/components/material/Button'
+import RouteCard from "~/components/RouteCard";
+import { fetcher } from "~/api";
+import Button from "~/components/material/Button";
 
-const PAGE_SIZE = 3
+const PAGE_SIZE = 3;
 
 type RouteListProps = {
-  class?: string
-  dongleId: string
-}
+  class?: string;
+  dongleId: string;
+};
 
-const pages: Promise<RouteSegments[]>[] = []
+const pages: Promise<RouteSegments[]>[] = [];
 
 const RouteList: VoidComponent<RouteListProps> = (props) => {
-  const endpoint = () => `/v1/devices/${props.dongleId}/routes_segments?limit=${PAGE_SIZE}`
+  const endpoint = () =>
+    `/v1/devices/${props.dongleId}/routes_segments?limit=${PAGE_SIZE}`;
   const getKey = (previousPageData?: RouteSegments[]): string | undefined => {
-    if (!previousPageData) return endpoint()
-    if (previousPageData.length === 0) return undefined
-    const lastSegmentEndTime = previousPageData.at(-1)!.end_time_utc_millis
-    return `${endpoint()}&end=${lastSegmentEndTime - 1}`
-  }
+    if (!previousPageData) return endpoint();
+    if (previousPageData.length === 0) return undefined;
+    const lastSegmentEndTime = previousPageData.at(-1)!.end_time_utc_millis;
+    return `${endpoint()}&end=${lastSegmentEndTime - 1}`;
+  };
   const getPage = (page: number): Promise<RouteSegments[]> => {
     if (!pages[page]) {
       // eslint-disable-next-line no-async-promise-executor
       pages[page] = new Promise(async (resolve) => {
-        const previousPageData = page > 0 ? await getPage(page - 1) : undefined
-        const key = getKey(previousPageData)
-        resolve(key ? fetcher<RouteSegments[]>(key) : [])
-      })
+        const previousPageData = page > 0 ? await getPage(page - 1) : undefined;
+        const key = getKey(previousPageData);
+        resolve(key ? fetcher<RouteSegments[]>(key) : []);
+      });
     }
-    return pages[page]
-  }
+    return pages[page];
+  };
 
   createEffect(() => {
     if (props.dongleId) {
-      pages.length = 0
-      setSize(1)
+      pages.length = 0;
+      setSize(1);
     }
-  })
+  });
 
-  const [size, setSize] = createSignal(1)
-  const onLoadMore = () => setSize(size() + 1)
-  const pageNumbers = () => Array.from(Array(size()).keys())
+  const [size, setSize] = createSignal(1);
+  const onLoadMore = () => setSize(size() + 1);
+  const pageNumbers = () => Array.from(Array(size()).keys());
+  const sortByCreateTime = (array: RouteSegments[]) => {
+    return array.sort((a, b) => b.create_time - a.create_time);
+  };
 
   return (
     <div
       class={clsx(
-        'flex w-full flex-col justify-items-stretch gap-4',
+        "flex w-full flex-col justify-items-stretch gap-4",
         props.class,
       )}
     >
       <For each={pageNumbers()}>
         {(i) => {
-          const [routes] = createResource(() => i, getPage)
+          const [routes] = createResource(() => i, getPage);
           return (
             <Suspense
               fallback={
@@ -75,18 +79,20 @@ const RouteList: VoidComponent<RouteListProps> = (props) => {
                 </>
               }
             >
-              <For each={routes()}>
-                {(route) => <RouteCard route={route} />}
-              </For>
+              {routes() && (
+                <For each={sortByCreateTime(routes())}>
+                  {(route) => <RouteCard route={route} />}
+                </For>
+              )}
             </Suspense>
-          )
+          );
         }}
       </For>
       <div class="flex justify-center">
         <Button onClick={onLoadMore}>Load more</Button>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default RouteList
+export default RouteList;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,100 +1,100 @@
 export interface ApiResponseBase {
-  fetched_at: number
+  fetched_at: number;
 }
 
 export interface Profile {
-  email: string
-  id: string
-  regdate: number
-  superuser: boolean
-  user_id: string
+  email: string;
+  id: string;
+  regdate: number;
+  superuser: boolean;
+  user_id: string;
 }
 
 export interface Device extends ApiResponseBase {
-  dongle_id: string
-  alias: string
-  serial: string
-  last_athena_ping: number
-  ignore_uploads: boolean | null
-  is_paired: boolean
-  is_owner: boolean
-  public_key: string
-  prime: boolean
-  prime_type: number
-  trial_claimed: boolean
-  device_type: string
-  openpilot_version: string
-  sim_id: string
-  sim_type: number
+  dongle_id: string;
+  alias: string;
+  serial: string;
+  last_athena_ping: number;
+  ignore_uploads: boolean | null;
+  is_paired: boolean;
+  is_owner: boolean;
+  public_key: string;
+  prime: boolean;
+  prime_type: number;
+  trial_claimed: boolean;
+  device_type: string;
+  openpilot_version: string;
+  sim_id: string;
+  sim_type: number;
   eligible_features: {
-    prime: boolean
-    prime_data: boolean
-    nav: boolean
-  }
+    prime: boolean;
+    prime_data: boolean;
+    nav: boolean;
+  };
 }
 
 export interface DrivingStatisticsAggregation {
-  distance: number
-  minutes: number
-  routes: number
+  distance: number;
+  minutes: number;
+  routes: number;
 }
 
 export interface DrivingStatistics {
-  all: DrivingStatisticsAggregation
-  week: DrivingStatisticsAggregation
+  all: DrivingStatisticsAggregation;
+  week: DrivingStatisticsAggregation;
 }
 
 export interface DeviceUser {
-  email: string
-  permission: 'read_access' | 'owner'
+  email: string;
+  permission: "read_access" | "owner";
 }
 
 export interface Route extends ApiResponseBase {
-  can?: boolean
-  create_time: number
-  devicetype: number
-  dongle_id: string
-  end_lat?: number
-  end_lng?: number
-  end_time?: string
-  fullname: string
-  git_branch?: string
-  git_commit?: string
-  git_dirty?: boolean
-  git_remote?: string
-  hpgps?: boolean
-  init_logmonotime?: number
-  is_public: boolean
-  length?: number
-  maxcamera: number
-  maxdcamera: number
-  maxecamera: number
-  maxlog: number
-  maxqcamera: number
-  maxqlog: number
-  passive?: boolean
-  platform?: string
-  proccamera: number
-  proclog: number
-  procqcamera: number
-  procqlog: number
-  radar?: boolean
-  start_time: string
-  url: string
-  user_id: string | null
-  version?: string
-  vin?: string
+  can?: boolean;
+  create_time: number;
+  devicetype: number;
+  dongle_id: string;
+  end_lat?: number;
+  end_lng?: number;
+  end_time?: string;
+  fullname: string;
+  git_branch?: string;
+  git_commit?: string;
+  git_dirty?: boolean;
+  git_remote?: string;
+  hpgps?: boolean;
+  init_logmonotime?: number;
+  is_public: boolean;
+  length?: number;
+  maxcamera: number;
+  maxdcamera: number;
+  maxecamera: number;
+  maxlog: number;
+  maxqcamera: number;
+  maxqlog: number;
+  passive?: boolean;
+  platform?: string;
+  proccamera: number;
+  proclog: number;
+  procqcamera: number;
+  procqlog: number;
+  radar?: boolean;
+  start_time: string;
+  url: string;
+  user_id: string | null;
+  version?: string;
+  vin?: string;
 }
 
 export interface RouteShareSignature extends Record<string, string> {
-  exp: string
-  sig: string
+  exp: string;
+  sig: string;
 }
 
 export interface RouteSegments extends Route {
-  end_time_utc_millis: number
-  is_preserved: boolean
-  share_exp: RouteShareSignature['exp']
-  share_sig: RouteShareSignature['sig']
-  start_time_utc_millis: number
+  end_time_utc_millis?: number;
+  is_preserved: boolean;
+  share_exp: RouteShareSignature["exp"];
+  share_sig: RouteShareSignature["sig"];
+  start_time_utc_millis?: number;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -46,7 +46,7 @@ export interface DrivingStatistics {
 
 export interface DeviceUser {
   email: string;
-  permission: "read_access" | "owner";
+  permission: 'read_access' | 'owner';
 }
 
 export interface Route extends ApiResponseBase {
@@ -94,7 +94,7 @@ export interface RouteShareSignature extends Record<string, string> {
 export interface RouteSegments extends Route {
   end_time_utc_millis?: number;
   is_preserved: boolean;
-  share_exp: RouteShareSignature["exp"];
-  share_sig: RouteShareSignature["sig"];
+  share_exp: RouteShareSignature['exp'];
+  share_sig: RouteShareSignature['sig'];
   start_time_utc_millis?: number;
 }


### PR DESCRIPTION
Fixes: #60 
Features:
- Hides date and time if it does not exist from `<RouteCard>`
- Sorts all routes ascendingly in order of `create_time`

Output of no date/time:

![Screen Shot 2024-11-29 at 02 42 25](https://github.com/user-attachments/assets/4d0b0812-7e30-4e6a-a134-21483a283b94)
