### PR TITLE
Color code the RouteList with some sort of "sunlight" color temperature, based on latitude & longitude and time of day

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,11 @@
         "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
         "hls.js": "^1.5.20",
+        "kelvin-to-rgb": "^1.0.2",
         "leaflet": "^1.9.4",
         "qr-scanner": "^1.4.2",
         "solid-js": "^1.9.5",
+        "suncalc": "^1.9.0",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -705,6 +707,8 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
+    "kelvin-to-rgb": ["kelvin-to-rgb@1.0.2", "", {}, "sha512-ZcHffRL/1wA5fuutLIai/DIV29NAnhMXITJYo/5q8f1h+Uz55qNKBEnJuLrwFZhK4ZVzxXzvX1zQXo1V/EbwRQ=="],
+
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "leaflet": ["leaflet@1.9.4", "", {}, "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="],
@@ -968,6 +972,8 @@
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="],
+
+    "suncalc": ["suncalc@1.9.0", "", {}, "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 

--- a/package.json
+++ b/package.json
@@ -65,8 +65,10 @@
     "clsx": "construct className strings conditionally",
     "dayjs": "work with dates (e.g., parse, validate, etc.)",
     "hls.js": "stream video data",
+    "kelvin-to-rgb": "approximate sunrise and sunset colors, so we can color code RouteList",
     "leaflet": "interactive maps",
-    "solid-js": "JS ui framework"
+    "solid-js": "JS ui framework",
+    "suncalc": "get sunrise and sunset times, so we can color code RouteList"
   },
   "dependencies": {
     "@mapbox/polyline": "^1.2.1",
@@ -77,9 +79,11 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
     "hls.js": "^1.5.20",
+    "kelvin-to-rgb": "^1.0.2",
     "leaflet": "^1.9.4",
     "qr-scanner": "^1.4.2",
-    "solid-js": "^1.9.5"
+    "solid-js": "^1.9.5",
+    "suncalc": "^1.9.0"
   },
   "engines": {
     "node": ">=20.11.0"

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -2,6 +2,8 @@ import {
   createEffect, createResource, createSignal, For, Index, onCleanup, onMount, Suspense, type VoidComponent,
 } from 'solid-js'
 import dayjs from 'dayjs'
+import SunCalc from 'suncalc'
+import kelvinToRgb from 'kelvin-to-rgb'
 
 import { fetcher } from '~/api'
 import Card, { CardContent, CardHeader } from '~/components/material/Card'
@@ -29,21 +31,81 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
     return `${startPlace} to ${endPlace}`
   })
 
+  const dayNightFraction = () => {
+    const times = SunCalc.getTimes(endTime(), props.route.end_lat, props.route.end_lng);
+    const now_ts = endTime().valueOf();
+
+    if (times.goldenHourEnd.valueOf() < now_ts && now_ts < times.goldenHour.valueOf()) {
+      // "Daytime"
+      return Number.POSITIVE_INFINITY;
+    } else if (times.nightEnd.valueOf() <= now_ts && now_ts <= times.night.valueOf()) {
+      // The idea here is to color code with some sort of "sunlight" color temperature, based on latitude & longitude and time of day
+      var percentage = 1.0;
+
+      // Temperature calculation from https://github.com/claytonjn/hass-circadian_lighting/blob/2f87bdaf86c602983c054b3f6fcd51a5198c1c20/custom_components/circadian_lighting/__init__.py#L295 instead
+      if(now_ts < times.solarNoon.valueOf()) {
+        percentage = 1.0 - Math.pow((times.solarNoon.valueOf() - now_ts)/(times.solarNoon.valueOf() - times.nightEnd.valueOf()), 2);
+      }
+      if(now_ts > times.solarNoon.valueOf()) {
+        percentage = 1.0 - Math.pow((now_ts - times.solarNoon.valueOf())/(times.night.valueOf() - times.solarNoon.valueOf()), 2);
+      }
+
+      // INVARIANT: If you get here, `percentage` is between 0.0 and 1.0
+      return percentage;
+    } else {
+      // "Nighttime"
+      return null;
+    }
+
+  };
+
+  const sunlightBorderStyle = () => {
+    const percentage = dayNightFraction();
+
+    if (percentage === null) {
+      // No border at night. (There's no sun at night, anyway.)
+      return '0px none transparent';
+    } else {
+      const max_w = Math.PI / 2;
+      const w = Math.sin(SunCalc.getPosition(endTime(), props.route.end_lat, props.route.end_lng).altitude) / max_w;
+      const sunBorderPx = 1 * (1 - w) + 4 * (w); // interpolate from 1px to 3px
+
+      var sunColorRgb;
+      if (0.0 <= percentage && percentage <= 1.0) {
+        const k = 2500 * (1 - percentage) + 5500 * (percentage); // interpolate from 2500K to 5500K
+        sunColorRgb = kelvinToRgb(k);
+      } else {
+        // If you want to actually calculate sky blue, you'll need something like https://github.com/elonen/js-sky-sim/blob/7e45f96a7842a1f8fc5a495d6bb15e914c54b0fb/sky-sim.html#L105
+        // Or if you want something trivially simple instead, try https://github.com/x8BitRain/meta-theme-sky-color
+        sunColorRgb = kelvinToRgb(40000);
+      }
+
+      return sunBorderPx + 'px solid rgb(' + sunColorRgb[0] + ',' + sunColorRgb[1] + ',' + sunColorRgb[2] + ')';
+    }
+
+  };
+
   return (
-    <Card
-      class="max-w-none"
-      href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`}
-      activeClass="md:before:bg-primary"
+    <div
+      style:border-radius="1.5ex"
+      style:border-top={sunlightBorderStyle()}
+      style:border-right={sunlightBorderStyle()}
     >
-      <CardHeader
+      <Card
+        class="max-w-none"
+        href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`}
+        activeClass="md:before:bg-primary"
+      >
+        <CardHeader
         headline={<div class="flex gap-2"><span>{startTime().format('ddd, MMM D, YYYY')}</span>&middot;<span>{startTime().format('h:mm A')} to {endTime().format('h:mm A')}</span></div>}
         subhead={location()}
-      />
+        />
 
-      <CardContent>
-        <RouteStatistics route={props.route} />
-      </CardContent>
-    </Card>
+        <CardContent>
+          <RouteStatistics route={props.route} />
+        </CardContent>
+      </Card>
+    </div>
   )
 }
 

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -31,27 +31,28 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
     return `${startPlace} to ${endPlace}`
   })
 
+
+  // The idea here is to color code with some sort of "sunlight" color temperature, based on latitude & longitude and time of day
+  // * @returns {number} between 0.0 for twilight and 1.0 for daytime, `Number.POSITIVE_INFINITY` at full brightness, and `null` at night
   const dayNightFraction = () => {
     const times = SunCalc.getTimes(endTime(), props.route.end_lat, props.route.end_lng);
     const now_ts = endTime().valueOf();
 
     if (times.goldenHourEnd.valueOf() < now_ts && now_ts < times.goldenHour.valueOf()) {
-      // "Daytime"
+      // "Broad daylight"
       return Number.POSITIVE_INFINITY;
     } else if (times.nightEnd.valueOf() <= now_ts && now_ts <= times.night.valueOf()) {
-      // The idea here is to color code with some sort of "sunlight" color temperature, based on latitude & longitude and time of day
-      var percentage = 1.0;
 
       // Temperature calculation from https://github.com/claytonjn/hass-circadian_lighting/blob/2f87bdaf86c602983c054b3f6fcd51a5198c1c20/custom_components/circadian_lighting/__init__.py#L295 instead
       if(now_ts < times.solarNoon.valueOf()) {
-        percentage = 1.0 - Math.pow((times.solarNoon.valueOf() - now_ts)/(times.solarNoon.valueOf() - times.nightEnd.valueOf()), 2);
+        return 1.0 - Math.pow((times.solarNoon.valueOf() - now_ts)/(times.solarNoon.valueOf() - times.nightEnd.valueOf()), 2);
       }
       if(now_ts > times.solarNoon.valueOf()) {
-        percentage = 1.0 - Math.pow((now_ts - times.solarNoon.valueOf())/(times.night.valueOf() - times.solarNoon.valueOf()), 2);
+        return 1.0 - Math.pow((now_ts - times.solarNoon.valueOf())/(times.night.valueOf() - times.solarNoon.valueOf()), 2);
       }
 
-      // INVARIANT: If you get here, `percentage` is between 0.0 and 1.0
-      return percentage;
+      return 1.0;
+
     } else {
       // "Nighttime"
       return null;
@@ -70,7 +71,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       const w = Math.sin(SunCalc.getPosition(endTime(), props.route.end_lat, props.route.end_lng).altitude) / max_w;
       const sunBorderPx = 1 * (1 - w) + 4 * (w); // interpolate from 1px to 3px
 
-      var sunColorRgb;
+      let sunColorRgb : [number, number, number];
       if (0.0 <= percentage && percentage <= 1.0) {
         const k = 2500 * (1 - percentage) + 5500 * (percentage); // interpolate from 2500K to 5500K
         sunColorRgb = kelvinToRgb(k);

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -60,16 +60,15 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
 
   };
 
-  const sunlightBorderStyle = () => {
+  const sunlightBackgroundStyle = () => {
     const percentage = dayNightFraction();
 
     if (percentage === null) {
-      // No border at night. (There's no sun at night, anyway.)
-      return '0px none transparent';
+      // No styling at night. (There's no sun at night, anyway.)
+      return 'none';
     } else {
       const max_w = Math.PI / 2;
-      const w = Math.sin(SunCalc.getPosition(endTime(), props.route.end_lat, props.route.end_lng).altitude) / max_w;
-      const sunBorderPx = 1 * (1 - w) + 4 * (w); // interpolate from 1px to 3px
+      const w = SunCalc.getPosition(endTime(), props.route.end_lat, props.route.end_lng).altitude / max_w;
 
       let sunColorRgb : [number, number, number];
       if (0.0 <= percentage && percentage <= 1.0) {
@@ -81,21 +80,21 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
         sunColorRgb = kelvinToRgb(40000);
       }
 
-      return sunBorderPx + 'px solid rgb(' + sunColorRgb[0] + ',' + sunColorRgb[1] + ',' + sunColorRgb[2] + ')';
+      return 'linear-gradient(rgba(' + sunColorRgb[0] + ' ' + sunColorRgb[1] + ' ' + sunColorRgb[2] + ' / ' + Math.round((1.0 + w) * 50) + '% ), rgb(27 27 33))';
+      // rgb(27, 27, 33) is the tailwind-material-colors background color for bg-surface-container-low (see Card in src/components/material/Card.tsx)
     }
 
   };
 
   return (
-    <div
-      style:border-radius="1.5ex"
-      style:border-top={sunlightBorderStyle()}
-      style:border-right={sunlightBorderStyle()}
+
+    <Card
+      class="max-w-none"
+      href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`}
+      activeClass="md:before:bg-primary"
     >
-      <Card
-        class="max-w-none"
-        href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`}
-        activeClass="md:before:bg-primary"
+      <div
+        style:background-image={sunlightBackgroundStyle()}
       >
         <CardHeader
         headline={<div class="flex gap-2"><span>{startTime().format('ddd, MMM D, YYYY')}</span>&middot;<span>{startTime().format('h:mm A')} to {endTime().format('h:mm A')}</span></div>}
@@ -105,8 +104,8 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
         <CardContent>
           <RouteStatistics route={props.route} />
         </CardContent>
-      </Card>
-    </div>
+      </div>
+    </Card>
   )
 }
 


### PR DESCRIPTION
The old connect.comma.ai shows the frames of video in the RouteList, which has the benefit that you can quickly see which were at daytime vs. nighttime based purely on the color themes of the frames. Showing all these frames makes loading too slow, so in the new connect this feature has been removed.

However, we still could at least color code each <a> with some sort of "sunlight" color temperature based on latitude & longitude and time of day instead. That way, if you're trying to quickly scroll down to a certain moment you had in mind you can do it easily without slowly (and carefully) reading every time of day line-by-line.

Original discussion here: https://discord.com/channels/469524606043160576/1244366765983535145/1345905314989342730
