### PR TITLE
feat: make connect uploads high priority

### DIFF
--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -16,8 +16,7 @@ export const FILE_NAMES = {
 const MAX_OPEN_REQUESTS = 15;
 const MAX_RETRIES = 5;
 
-// Connect uploads should be highest priority as they are user requested.
-// 0 is highest priority.
+// connect uploads should be high priority as they are user requested (lower is higher)
 const HIGH_PRIORITY = 0;
 
 let uploadQueueTimeout = null;

--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -16,6 +16,10 @@ export const FILE_NAMES = {
 const MAX_OPEN_REQUESTS = 15;
 const MAX_RETRIES = 5;
 
+// Connect uploads should be highest priority as they are user requested.
+// 0 is highest priority.
+const HIGH_PRIORITY = 0;
+
 let uploadQueueTimeout = null;
 let openRequests = 0;
 
@@ -217,6 +221,7 @@ export function doUpload(dongleId, paths, urls) {
         url: urls[i],
         headers: { 'x-ms-blob-type': 'BlockBlob' },
         allow_cellular: false,
+        priority: HIGH_PRIORITY,
       }));
       const payload = {
         id: 0,


### PR DESCRIPTION
**Description**

Related to:
- https://github.com/commaai/openpilot/issues/34836
- https://github.com/commaai/openpilot/pull/34856

Today, Firehose uploads and user-requested uploads from Connect are treated the same. This is not ideal behavior if the user wants to upload routes immediately for a bug report and the queue is full of uploads for Firehose. The workaround is to clear the queue and retry the upload from Connect.

This PR marks uploads requested by `connect` as highest priority.