### PR TITLE
feat: notify device of viewed routes

### DIFF
--- a/src/api/athena.ts
+++ b/src/api/athena.ts
@@ -31,6 +31,9 @@ export const uploadFilesToUrls = (dongleId: string, files: UploadFile[]) =>
     })),
   }, Math.floor(Date.now() / 1000) + EXPIRES_IN_SECONDS)
 
+export const setRouteViewed = (dongleId: string, route: string) =>
+  makeAthenaCall<{ route: string }, void>(dongleId, 'setRouteViewed', { route })
+
 export const makeAthenaCall = async <REQ, RES>(dongleId: string, method: string, params?: REQ, expiry?: number): Promise<AthenaCallResponse<RES>> => {
   const res = await fetcher<BackendAthenaCallResponse<RES> | BackendAthenaCallResponseError>(`/${dongleId}`, {
     method: 'POST',

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -1,11 +1,6 @@
-import {
-  createResource,
-  createSignal,
-  lazy,
-  Suspense,
-  type VoidComponent,
-} from 'solid-js'
+import { createResource, createSignal, lazy, onMount, Suspense, type VoidComponent } from 'solid-js'
 
+import { setRouteViewed } from '~/api/athena'
 import { getRoute } from '~/api/route'
 import { dayjs } from '~/utils/format'
 
@@ -37,6 +32,11 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
     const video = videoRef()
     if (video) video.currentTime = newTime
   }
+
+  onMount(async () => {
+    // FIXME: don't send for shared devices, unless superuser
+    await setRouteViewed(props.dongleId, props.dateStr)
+  })
 
   return (
     <>


### PR DESCRIPTION
Call `setRouteViewed` athena method with the route ID when opening a route.

TODO:
- [x] don't try to call methods on devices not owned by the user (shared devices/public routes)
- [x] DO call the method if user is a superuser

Closes #221