### PR TITLE
refactor: add type-checked name prop to Icon component

### DIFF
--- a/src/components/DeviceLocation.tsx
+++ b/src/components/DeviceLocation.tsx
@@ -8,6 +8,7 @@ import Button from './material/Button'
 
 import { getDeviceLocation } from '~/api/devices'
 import Card from '~/components/material/Card'
+import type { IconName } from '~/components/material/Icon'
 import IconButton from '~/components/material/IconButton'
 import { getTileUrl } from '~/map'
 import { getFullAddress } from '~/map/geocode'
@@ -128,13 +129,13 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
     },
   )
 
-  const addMarker = (instance: L.Map, loc: Location, iconName: string, iconClass?: string) => {
+  const addMarker = (instance: L.Map, loc: Location, iconName: IconName, iconClass?: string) => {
     const el = document.createElement('div')
 
     render(
       () => (
         <div class={clsx('flex size-[40px] items-center justify-center rounded-full bg-primary-container', iconClass)}>
-          <Icon>{iconName}</Icon>
+          <Icon name={iconName} />
         </div>
       ),
       el,
@@ -175,7 +176,7 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
             onClick={() => void requestUserLocation()}
             trailing={<span class="pr-2 text-sm">Show my location</span>}
           >
-            <Icon size="20">my_location</Icon>
+            <Icon name="my_location" size="20" />
           </Button>
         </div>
       </Show>
@@ -189,9 +190,7 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
 
       <Show when={(locationData.error as Error)?.message}>
         <div class="absolute left-1/2 top-1/2 z-[5000] flex -translate-x-1/2 -translate-y-1/2 items-center rounded-full bg-surface-variant px-4 py-2 shadow">
-          <Icon class="mr-2" size="20">
-            error
-          </Icon>
+          <Icon class="mr-2" name="error" size="20" />
           <span class="text-sm">{(locationData.error as Error).message}</span>
         </div>
       </Show>
@@ -204,14 +203,14 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
       >
         <div class="mb-2 flex flex-row items-center justify-between gap-4">
           <span class="truncate text-title-md">{selectedLocation()?.label}</span>
-          <IconButton onClick={() => setShowSelectedLocation(false)}>close</IconButton>
+          <IconButton name="close" onClick={() => setShowSelectedLocation(false)} />
         </div>
         <div class="flex flex-col items-end gap-3 xs:flex-row">
           <span class="text-body-md text-on-surface-variant">{selectedLocation()?.address}</span>
           <Button
             color="secondary"
             onClick={() => window.open(`https://www.google.com/maps?q=${selectedLocation()!.lat},${selectedLocation()!.lng}`, '_blank')}
-            trailing={<Icon size="20">open_in_new</Icon>}
+            trailing={<Icon name="open_in_new" size="20" />}
           >
             Open in Maps
           </Button>

--- a/src/components/RouteActions.tsx
+++ b/src/components/RouteActions.tsx
@@ -112,9 +112,7 @@ const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
             <span class="break-keep inline-block">{currentRouteId().split('/')[0] || ''}/</span>
             <span class="break-keep inline-block">{currentRouteId().split('/')[1] || ''}</span>
           </div>
-          <Icon size="20" class={clsx('px-2', copied() && 'text-green-300')}>
-            {copied() ? 'check' : 'file_copy'}
-          </Icon>
+          <Icon class={clsx('px-2', copied() && 'text-green-300')} name={copied() ? 'check' : 'file_copy'} size="20" />
         </button>
       </div>
 
@@ -125,9 +123,7 @@ const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
 
       <Show when={error()}>
         <div class="flex gap-2 rounded-sm bg-surface-container-high p-2 text-body-md text-on-surface">
-          <Icon class="text-error" size="20">
-            error
-          </Icon>
+          <Icon class="text-error" name="error" size="20" />
           {error()}
         </div>
       </Show>

--- a/src/components/RouteStaticMap.tsx
+++ b/src/components/RouteStaticMap.tsx
@@ -60,10 +60,10 @@ const RouteStaticMap: VoidComponent<RouteStaticMapProps> = (props) => {
     <div class={clsx('relative isolate flex h-full flex-col justify-end self-stretch bg-surface text-on-surface', props.class)}>
       <Switch>
         <Match when={!!coords.error || !!url.error || !!loadedUrl.error} keyed>
-          <State trailing={<Icon filled>error</Icon>}>Problem loading map</State>
+          <State trailing={<Icon name="error" filled />}>Problem loading map</State>
         </Match>
         <Match when={coords()?.length === 0} keyed>
-          <State trailing={<Icon filled>satellite_alt</Icon>}>No GPS data</State>
+          <State trailing={<Icon name="satellite_alt" filled />}>No GPS data</State>
         </Match>
         <Match when={url() && loadedUrl()} keyed>
           <img class="pointer-events-none size-full object-cover" src={loadedUrl()} alt="" />

--- a/src/components/RouteUploadButtons.tsx
+++ b/src/components/RouteUploadButtons.tsx
@@ -3,14 +3,14 @@ import { createStore } from 'solid-js/store'
 import clsx from 'clsx'
 
 import { getRouteWithSegments } from '~/api/route'
-import Icon from '~/components/material/Icon'
+import Icon, { type IconName } from '~/components/material/Icon'
 import Button from './material/Button'
 import { FileTypes, uploadAllSegments } from '~/api/upload'
 
 interface UploadButtonProps {
   state: 'idle' | 'loading' | 'success' | 'error'
   onClick?: () => void
-  icon: string
+  icon: IconName
   text: string
 }
 
@@ -27,7 +27,7 @@ const UploadButton: VoidComponent<UploadButtonProps> = (props) => {
     }
   }
 
-  const stateToIcon: Record<Exclude<UploadButtonProps['state'], null | undefined>, string> = {
+  const stateToIcon: Record<Exclude<UploadButtonProps['state'], null | undefined>, IconName> = {
     idle: icon(),
     loading: 'progress_activity',
     success: 'check',
@@ -39,11 +39,7 @@ const UploadButton: VoidComponent<UploadButtonProps> = (props) => {
       onClick={() => handleUpload()}
       class="px-2 md:px-3"
       disabled={disabled()}
-      leading={
-        <Icon size="20" class={clsx(state() === 'loading' && 'animate-spin')}>
-          {stateToIcon[state()]}
-        </Icon>
-      }
+      leading={<Icon class={clsx(state() === 'loading' && 'animate-spin')} name={stateToIcon[state()]} size="20" />}
       color="primary"
     >
       <span class="flex items-center gap-1 font-mono">{props.text}</span>

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -22,7 +22,7 @@ export const DrawerToggleButton: VoidComponent = () => {
   const { modal, setOpen } = useDrawerContext()
   return (
     <Show when={modal()}>
-      <IconButton onClick={() => setOpen((prev) => !prev)}>menu</IconButton>
+      <IconButton name="menu" onClick={() => setOpen((prev) => !prev)} />
     </Show>
   )
 }

--- a/src/components/material/Icon.tsx
+++ b/src/components/material/Icon.tsx
@@ -1,9 +1,20 @@
-import { Component } from 'solid-js'
+import { type VoidComponent } from 'solid-js'
 import clsx from 'clsx'
+
+// Specify icon names to load only the necessary icons, reducing font payload.
+// https://developers.google.com/fonts/docs/material_symbols#optimize_the_icon_font
+// biome-ignore format: the array should not be formatted
+export const Icons = [
+  'add', 'arrow_back', 'camera', 'check', 'chevron_right', 'clear', 'close', 'description', 'directions_car', 'download', 'error',
+  'file_copy', 'info', 'menu', 'my_location', 'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt', 'search',
+  'settings', 'sync', 'upload', 'videocam',
+] as const
+
+export type IconName = (typeof Icons)[number]
 
 export type IconProps = {
   class?: string
-  children: string
+  name: IconName
   filled?: boolean
   size?: '20' | '24' | '40' | '48'
 }
@@ -15,12 +26,12 @@ export type IconProps = {
  *
  * @see https://fonts.google.com/icons
  */
-const Icon: Component<IconProps> = (props) => {
+const Icon: VoidComponent<IconProps> = (props) => {
   // size-20, 24 etc. defined in root.css
   const size = () => `size-${props.size || '24'}`
   return (
     <span class={clsx('material-symbols-outlined flex', props.filled ? 'icon-filled' : 'icon-outline', size(), props.class)}>
-      {props.children}
+      {props.name}
     </span>
   )
 }

--- a/src/components/material/IconButton.tsx
+++ b/src/components/material/IconButton.tsx
@@ -1,17 +1,17 @@
-import type { Component } from 'solid-js'
+import type { VoidComponent } from 'solid-js'
 import { splitProps } from 'solid-js'
 import clsx from 'clsx'
 
 import ButtonBase, { ButtonBaseProps } from './ButtonBase'
-import Icon, { IconProps } from '~/components/material/Icon'
+import Icon, { type IconName, type IconProps } from '~/components/material/Icon'
 
 type IconButtonProps = ButtonBaseProps & {
-  children: string
+  name: IconName
   filled?: IconProps['filled']
   size?: IconProps['size']
 }
 
-const IconButton: Component<IconButtonProps> = (props) => {
+const IconButton: VoidComponent<IconButtonProps> = (props) => {
   const size = () => props.size || '24'
   const buttonSize = () =>
     ({
@@ -30,9 +30,7 @@ const IconButton: Component<IconButtonProps> = (props) => {
       )}
       {...rest}
     >
-      <Icon filled={props.filled} size={size()}>
-        {props.children}
-      </Icon>
+      <Icon name={props.name} filled={props.filled} size={size()} />
     </ButtonBase>
   )
 }

--- a/src/components/material/NavigationBar.tsx
+++ b/src/components/material/NavigationBar.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx'
 import Icon, { IconProps } from '~/components/material/Icon'
 
 type NavigationBarItemProps = {
-  icon: IconProps['children']
+  icon: IconProps['name']
   href: string
   selected?: boolean
 }
@@ -19,9 +19,7 @@ export const NavigationBarItem: ParentComponent<NavigationBarItemProps> = (props
       activeClass="text-on-surface before:bg-on-surface before:opacity-[.12]"
       inactiveClass="text-on-surface-variant before:bg-on-surface-variant"
     >
-      <Icon class="flex transition-all" filled={props.selected}>
-        {props.icon}
-      </Icon>
+      <Icon class="flex transition-all" name={props.icon} filled={props.selected} />
       <div class="mt-2 flex text-label-lg">{props.children}</div>
     </A>
   )

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -55,7 +55,7 @@ export default function Login() {
           <img src="/images/icon-comma-three-light.svg" alt="" width={32} height={32} />
         </div>
 
-        <Button onclick={loginAsDemoUser} trailing={<Icon>chevron_right</Icon>}>
+        <Button onclick={loginAsDemoUser} trailing={<Icon name="chevron_right" />}>
           Try the demo
         </Button>
       </div>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -34,7 +34,7 @@ const DashboardDrawer: VoidComponent<DashboardDrawerProps> = (props) => {
         component="h1"
         leading={
           <Show when={modal()}>
-            <IconButton onClick={onClose}>arrow_back</IconButton>
+            <IconButton name="arrow_back" onClick={onClose} />
           </Show>
         }
       >
@@ -45,7 +45,7 @@ const DashboardDrawer: VoidComponent<DashboardDrawerProps> = (props) => {
         {(devices) => <DeviceList class="overflow-y-auto p-2" devices={devices} />}
       </Show>
       <div class="grow" />
-      <Button class="m-4" leading={<Icon>add</Icon>} href="/pair" onClick={onClose}>
+      <Button class="m-4" leading={<Icon name="add" />} href="/pair" onClick={onClose}>
         Add new device
       </Button>
       <hr class="mx-4 opacity-20" />
@@ -119,7 +119,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
                 <Switch
                   fallback={
                     <div class="hidden size-full flex-col items-center justify-center gap-4 md:flex">
-                      <Icon size="48">search</Icon>
+                      <Icon name="search" size="48" />
                       <span class="text-title-md">Select a route to view</span>
                     </div>
                   }

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -101,7 +101,7 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
 
   return (
     <>
-      <TopAppBar leading={<DrawerToggleButton />} trailing={<IconButton href={`/${props.dongleId}/settings`}>settings</IconButton>}>
+      <TopAppBar leading={<DrawerToggleButton />} trailing={<IconButton name="settings" href={`/${props.dongleId}/settings`} />}>
         {deviceName()}
       </TopAppBar>
       <div class="flex flex-col gap-4 px-4 pb-4">
@@ -116,7 +116,7 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
               </Suspense>
             </div>
             <div class="flex p-4">
-              <IconButton onClick={() => void takeSnapshot()}>camera</IconButton>
+              <IconButton name="camera" onClick={() => void takeSnapshot()} />
             </div>
           </div>
         </div>
@@ -127,12 +127,8 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
                 <div class="relative p-4">
                   <img src={`data:image/jpeg;base64,${image}`} alt={`Device Snapshot ${index() + 1}`} />
                   <div class="absolute right-4 top-4 p-4">
-                    <IconButton onClick={() => downloadSnapshot(image, index())} class="text-white">
-                      download
-                    </IconButton>
-                    <IconButton onClick={() => clearImage(index())} class="text-white">
-                      clear
-                    </IconButton>
+                    <IconButton class="text-white" name="download" onClick={() => downloadSnapshot(image, index())} />
+                    <IconButton class="text-white" name="clear" onClick={() => clearImage(index())} />
                   </div>
                 </div>
               </div>
@@ -148,9 +144,7 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
           {snapshot().error && (
             <div class="flex-1 overflow-hidden rounded-lg bg-surface-container-low">
               <div class="flex items-center p-4">
-                <IconButton onClick={clearError} class="text-white">
-                  Clear
-                </IconButton>
+                <IconButton class="text-white" name="clear" onClick={clearError} />
                 <span>Error: {snapshot().error}</span>
               </div>
             </div>

--- a/src/pages/dashboard/activities/PairActivity.tsx
+++ b/src/pages/dashboard/activities/PairActivity.tsx
@@ -68,7 +68,7 @@ const PairActivity: VoidComponent = () => {
           <div id="video-container" class="fixed inset-0 bg-black text-white">
             <video class="absolute inset-0 size-full object-cover" ref={videoRef} />
             <div class="prose absolute inset-0 flex flex-col justify-between pb-7">
-              <TopAppBar trailing={<IconButton href="/">close</IconButton>}>Add new device</TopAppBar>
+              <TopAppBar trailing={<IconButton name="close" href="/" />}>Add new device</TopAppBar>
               <h2 class="px-8 text-center text-title-md">Use the viewfinder to scan the QR code on your device</h2>
             </div>
           </div>
@@ -104,7 +104,7 @@ const PairActivity: VoidComponent = () => {
       error(input, to) {
         return (
           <>
-            <TopAppBar trailing={<IconButton href="/">close</IconButton>}>Add new device</TopAppBar>
+            <TopAppBar trailing={<IconButton name="close" href="/" />}>Add new device</TopAppBar>
 
             <div class="flex flex-col items-center gap-4">
               An error occurred: {input.error.message}

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -47,15 +47,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
 
   return (
     <>
-      <TopAppBar
-        leading={
-          <IconButton class="md:hidden" href={`/${props.dongleId}`}>
-            arrow_back
-          </IconButton>
-        }
-      >
-        {startTime()}
-      </TopAppBar>
+      <TopAppBar leading={<IconButton class="md:hidden" name="arrow_back" href={`/${props.dongleId}`} />}>{startTime()}</TopAppBar>
 
       <div class="flex flex-col gap-6 px-4 pb-4">
         <Suspense fallback={<div class="skeleton-loader aspect-[241/151] rounded-lg bg-surface-container-low" />}>

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -200,9 +200,7 @@ const PrimeCheckout: VoidComponent<{ dongleId: string }> = (props) => {
 
       <Show when={stripeCancelled()}>
         <div class="flex gap-2 rounded-sm bg-surface-container p-2 text-body-md text-on-surface">
-          <Icon class="text-error" size="20">
-            error
-          </Icon>
+          <Icon name="error" class="text-error" size="20" />
           Checkout cancelled
         </div>
       </Show>
@@ -220,7 +218,7 @@ const PrimeCheckout: VoidComponent<{ dongleId: string }> = (props) => {
       <Show when={uiState()?.disabledDataPlanText} keyed>
         {(text) => (
           <div class="flex gap-2 rounded-sm bg-surface-container p-2 text-body-md text-on-surface">
-            <Icon size="20">info</Icon>
+            <Icon name="info" size="20" />
             {text}
           </div>
         )}
@@ -290,7 +288,7 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
         <Switch>
           <Match when={stripeSession.state === 'errored'}>
             <div class="flex gap-2 rounded-sm bg-on-error-container p-2 text-body-md font-semibold text-error-container">
-              <Icon size="20">error</Icon>
+              <Icon name="error" size="20" />
               Unable to check payment status: {stripeSession.error}
             </div>
           </Match>
@@ -299,21 +297,21 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
               <Switch>
                 <Match when={paymentStatus === 'unpaid'}>
                   <div class="flex gap-2 rounded-sm bg-surface-container p-2 text-body-md text-on-surface">
-                    <Icon size="20">payments</Icon>
+                    <Icon name="payments" size="20" />
                     Waiting for confirmed payment...
                   </div>
                 </Match>
 
                 <Match when={paymentStatus === 'paid' && !subscription()}>
                   <div class="flex gap-2 rounded-sm bg-surface-container p-2 text-body-md text-on-surface">
-                    <Icon size="20">sync</Icon>
+                    <Icon name="sync" size="20" />
                     Processing subscription...
                   </div>
                 </Match>
 
                 <Match when={paymentStatus === 'paid' && subscription()}>
                   <div class="flex gap-2 rounded-sm bg-tertiary-container p-2 text-body-md text-on-tertiary-container">
-                    <Icon size="20">check</Icon>
+                    <Icon name="check" size="20" />
                     <div class="flex flex-col gap-2">
                       <p class="font-semibold">comma prime activated</p>
                       <Show when={subscription()?.is_prime_sim} keyed>
@@ -331,16 +329,14 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
         <Switch>
           <Match when={cancelData.state === 'errored'}>
             <div class="flex gap-2 rounded-sm bg-surface-container p-2 text-body-md text-on-surface">
-              <Icon class="text-error" size="20">
-                error
-              </Icon>
+              <Icon class="text-error" name="error" size="20" />
               Failed to cancel subscription: {cancelData.error}
             </div>
           </Match>
 
           <Match when={cancelData.state === 'ready'}>
             <div class="flex gap-2 rounded-sm bg-surface-container p-2 text-body-md text-on-surface">
-              <Icon size="20">check</Icon>
+              <Icon name="check" size="20" />
               Subscription cancelled
             </div>
           </Match>
@@ -407,15 +403,7 @@ const SettingsActivity: VoidComponent<PrimeActivityProps> = (props) => {
   const [device] = createResource(() => props.dongleId, getDevice)
   return (
     <>
-      <TopAppBar
-        leading={
-          <IconButton class="md:hidden" href={`/${props.dongleId}`}>
-            arrow_back
-          </IconButton>
-        }
-      >
-        Device Settings
-      </TopAppBar>
+      <TopAppBar leading={<IconButton class="md:hidden" name="arrow_back" href={`/${props.dongleId}`} />}>Device Settings</TopAppBar>
       <div class="max-w-lg px-4">
         <h2 class="mb-4 text-headline-sm">comma prime</h2>
         <Suspense>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,8 @@ import solid from 'vite-plugin-solid'
 import devtools from 'solid-devtools/vite'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 
-import { Icons } from '~/components/material/Icon'
+// noinspection ES6PreferShortImport
+import { Icons } from './src/components/material/Icon'
 
 export default defineConfig({
   plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import solid from 'vite-plugin-solid'
 import devtools from 'solid-devtools/vite'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 
+import { Icons } from '~/components/material/Icon'
+
 export default defineConfig({
   plugins: [
     devtools(),
@@ -17,14 +19,7 @@ export default defineConfig({
     {
       name: 'inject-material-symbols',
       transformIndexHtml(html) {
-        // Specify icon names to load only the necessary icons, reducing font payload.
-        // https://developers.google.com/fonts/docs/material_symbols#optimize_the_icon_font
-        // biome-ignore format: the array should not be formatted
-        const icons = [
-          'add', 'arrow_back', 'camera', 'check', 'chevron_right', 'clear', 'close', 'description', 'directions_car', 'download',
-          'error', 'file_copy', 'info', 'menu', 'my_location', 'open_in_new', 'payments', 'person', 'progress_activity',
-          'satellite_alt', 'search', 'settings', 'sync', 'upload', 'videocam',
-        ].toSorted().join(',')
+        const icons = Icons.toSorted().join(',')
         return {
           html,
           tags: [


### PR DESCRIPTION
This type-checked prop will allow us to avoid using new icons without adding them to the icons list. The Material Symbols font URL can be generated from the same list of icon names.