### PR TITLE
refactor: athena types, add missing priority field

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -131,14 +131,13 @@ export interface Files {
   qlogs: string[]
 }
 
-export type AthenaOfflineQueueResponse = AthenaOfflineQueueItem[]
+export type AthenaOfflineQueueResponse = AthenaOfflineQueueItem<unknown>[]
 
 export interface AthenaOfflineQueueItemParams {
   files_data: [string, string, Record<string, string>][]
 }
 
-export interface AthenaOfflineQueueItem extends ApiResponseBase, AthenaCallRequest<UploadFilesToUrlsRequest> {
-  method: 'uploadFilesToUrls'
+export interface AthenaOfflineQueueItem<T> extends ApiResponseBase, AthenaCallRequest<T> {
   expiry: number
 }
 
@@ -170,6 +169,7 @@ export interface DataFile {
   allow_cellular: boolean
   fn: string
   headers: Record<string, string>
+  priority: number
   url: string
 }
 


### PR DESCRIPTION
athena offline queue can hold any types of athena calls.