### PR TITLE
cleanup(dashboard): fetch devices where they are used

### DIFF
--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx'
 
 import { getDevices } from '~/api/devices'
 import { getProfile } from '~/api/profile'
-import type { Device } from '~/types'
 import storage from '~/utils/storage'
 
 import Button from '~/components/material/Button'
@@ -21,11 +20,7 @@ import SettingsActivity from './activities/SettingsActivity'
 
 const PairActivity = lazy(() => import('./activities/PairActivity'))
 
-interface DashboardDrawerProps {
-  devices?: Device[]
-}
-
-const DashboardDrawer: VoidComponent<DashboardDrawerProps> = (props) => {
+const DashboardDrawer: VoidComponent = () => {
   const { modal, setOpen } = useDrawerContext()
   const onClose = () => setOpen(false)
   return (
@@ -41,9 +36,7 @@ const DashboardDrawer: VoidComponent<DashboardDrawerProps> = (props) => {
         comma connect
       </TopAppBar>
       <h2 class="mx-4 mb-2 text-label-sm uppercase">Devices</h2>
-      <Show when={props.devices} keyed>
-        {(devices) => <DeviceList class="overflow-y-auto p-2" devices={devices} />}
-      </Show>
+      <DeviceList class="overflow-y-auto p-2" />
       <div class="grow" />
       <Button class="m-4" leading={<Icon name="add" />} href="/pair" onClick={onClose}>
         Add new device
@@ -103,7 +96,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
   }
 
   return (
-    <Drawer drawer={<DashboardDrawer devices={devices()} />}>
+    <Drawer drawer={<DashboardDrawer />}>
       <Switch fallback={<TopAppBar leading={<DrawerToggleButton />}>No device</TopAppBar>}>
         <Match when={!!profile.error}>
           <Navigate href="/login" />

--- a/src/pages/dashboard/components/DeviceList.tsx
+++ b/src/pages/dashboard/components/DeviceList.tsx
@@ -1,7 +1,8 @@
-import { For, type VoidComponent } from 'solid-js'
+import { createResource, For, Suspense, type VoidComponent } from 'solid-js'
 import { useLocation } from '@solidjs/router'
 import clsx from 'clsx'
 
+import { getDevices } from '~/api/devices'
 import { useDrawerContext } from '~/components/material/Drawer'
 import List, { ListItem, ListItemContent } from '~/components/material/List'
 import type { Device } from '~/types'
@@ -10,7 +11,6 @@ import storage from '~/utils/storage'
 
 type DeviceListProps = {
   class?: string
-  devices: Device[]
 }
 
 const DeviceList: VoidComponent<DeviceListProps> = (props) => {
@@ -23,11 +23,12 @@ const DeviceList: VoidComponent<DeviceListProps> = (props) => {
     storage.setItem('lastSelectedDongleId', device.dongle_id)
   }
 
+  const [devices] = createResource(getDevices)
   return (
     <List variant="nav" class={props.class}>
-      <For each={props.devices}>
-        {(device) => {
-          return (
+      <Suspense fallback={<div class="h-14 skeleton-loader rounded-xl" />}>
+        <For each={devices()}>
+          {(device) => (
             <ListItem
               variant="nav"
               leading={<div class={clsx('m-2 size-2 shrink-0 rounded-full', deviceIsOnline(device) ? 'bg-green-400' : 'bg-gray-400')} />}
@@ -41,9 +42,9 @@ const DeviceList: VoidComponent<DeviceListProps> = (props) => {
                 subhead={<span class="font-mono text-label-sm lowercase">{device.dongle_id}</span>}
               />
             </ListItem>
-          )
-        }}
-      </For>
+          )}
+        </For>
+      </Suspense>
     </List>
   )
 }


### PR DESCRIPTION
Instead of prop drilling, we can just fetch the list of devices where they are used. We should use a query library to cache/de-duplicate requests.