### PR TITLE
feat: upload queue

### DIFF
--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -1,23 +1,110 @@
-import { VoidComponent, createEffect } from 'solid-js'
-import { getUploadQueue } from '~/api/athena'
-import { createQuery } from '~/utils/createQuery'
-import StatisticBar from './StatisticBar'
+import { createSignal, For, Match, onCleanup, Switch, VoidComponent } from 'solid-js'
+import { COMMA_CONNECT_PRIORITY, getUploadQueue } from '~/api/athena'
+import { UploadQueueItem } from '~/types'
+import LinearProgress from './material/LinearProgress'
+import Icon from './material/Icon'
+import { createStore, reconcile } from 'solid-js/store'
+
+interface DecoratedUploadQueueItem extends UploadQueueItem {
+  route: string
+  segment: number
+  filename: string
+}
+
+const parseUploadPath = (url: string) => {
+  const parts = new URL(url).pathname.split('/')
+  const route = parts[3]
+  const segment = parseInt(parts[4], 10)
+  const filename = parts[5]
+
+  return { route, segment, filename }
+}
+
+const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ item }) => {
+  return (
+    <div class="flex flex-col">
+      <div class={'flex items-center justify-between flex-wrap mb-1 gap-x-4 min-w-0'}>
+        <div class="flex items-center min-w-0 flex-1">
+          <Icon
+            class="text-on-surface-variant flex-shrink-0 mr-2"
+            name={item.priority === COMMA_CONNECT_PRIORITY ? 'person' : 'local_fire_department'}
+          />
+          <div class="flex min-w-0 gap-1">
+            <span class="text-body-sm font-mono truncate text-on-surface">{[item.route, item.segment, item.filename].join(' ')}</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-2 flex-shrink-0 justify-end">
+          <span class="text-body-sm font-mono whitespace-nowrap">{Math.round(item.progress * 100)}%</span>
+        </div>
+      </div>
+      <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-container-highest">
+        <LinearProgress progress={item.progress} color={'primary'} />
+      </div>
+    </div>
+  )
+}
 
 const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
-  const [queue] = createQuery({
-    source: () => props.dongleId,
-    fetcher: getUploadQueue,
-    refetchInterval: 2000,
+  const [loading, setLoading] = createSignal(true)
+  const [items, setItems] = createStore<DecoratedUploadQueueItem[]>([])
+  const [error, setError] = createSignal<string | undefined>()
+
+  let timeout: Timer | undefined
+
+  const fetch = () => {
+    getUploadQueue(props.dongleId)
+      .then((res) => {
+        if (res.error) {
+          setError(res.error)
+          return
+        }
+        setItems(
+          reconcile(res.result?.map((item) => ({ ...item, ...parseUploadPath(item.url) })).sort((a, b) => b.progress - a.progress) || []),
+        )
+      })
+      .catch((error) => {
+        if (error instanceof Error && error.cause instanceof Response && error.cause.status === 404) {
+          setError('Device offline')
+        } else {
+          setError(error.message)
+        }
+      })
+      .finally(() => {
+        if (!timeout) return
+        setLoading(false)
+        timeout = setTimeout(fetch, 2000)
+      })
+  }
+
+  timeout = setTimeout(fetch, 0)
+
+  onCleanup(() => {
+    clearTimeout(timeout)
+    timeout = undefined
   })
-  createEffect(() => {
-    console.log(queue()?.result)
-  })
+
   return (
     <div class="flex flex-col border-2 border-t-0 border-surface-container-high bg-surface-container-lowest">
-      <div class="flex-auto p-4">
-        <StatisticBar statistics={[{ label: 'Total', value: () => queue()?.result?.length }]} />
+      <div class="flex flex-col flex-auto p-4 gap-4">
+        <div class="relative h-[calc(4*3rem)] sm:h-[calc(6*3rem)] flex justify-center items-center text-on-surface-variant">
+          <Switch>
+            <Match when={loading()}>
+              <span>Loading...</span>
+            </Match>
+            <Match when={error()}>
+              <span>{error()}</span>
+            </Match>
+            <Match when={items.length === 0}>
+              <span>Queue is empty</span>
+            </Match>
+            <Match when={true}>
+              <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto hide-scrollbar">
+                <For each={items}>{(item) => <UploadQueueRow item={item} />}</For>
+              </div>
+            </Match>
+          </Switch>
+        </div>
       </div>
-      <div class="rounded-md border-2 border-surface-container-high mx-4 mb-4 p-4"></div>
     </div>
   )
 }

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -44,9 +44,8 @@ const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ ite
 const WAITING = 'Waiting for device to connect...'
 
 const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
-  const [error, setError] = createSignal<string | undefined>()
+  const [error, setError] = createSignal<string | undefined>(WAITING)
   const [items, setItems] = createStore<DecoratedUploadQueueItem[]>([])
-  const [loading, setLoading] = createSignal(true)
 
   let timeout: Timer | undefined
 
@@ -70,7 +69,6 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
       })
       .finally(() => {
         if (!timeout) return
-        setLoading(false)
         timeout = setTimeout(fetch, 1000)
       })
   }
@@ -87,9 +85,6 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
       <div class="flex flex-col flex-auto p-4 gap-4">
         <div class="relative h-[calc(4*3rem)] sm:h-[calc(6*3rem)] flex justify-center items-center text-on-surface-variant">
           <Switch>
-            <Match when={loading()}>
-              <Icon name="progress_activity" class="animate-spin" />
-            </Match>
             <Match when={error()}>
               <Icon class={clsx(error() === WAITING && 'animate-spin')} name={error() === WAITING ? 'progress_activity' : 'error'} />
               <span class="ml-2">{error()}</span>

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -41,9 +41,9 @@ const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ ite
 }
 
 const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
-  const [loading, setLoading] = createSignal(true)
-  const [items, setItems] = createStore<DecoratedUploadQueueItem[]>([])
   const [error, setError] = createSignal<string | undefined>()
+  const [items, setItems] = createStore<DecoratedUploadQueueItem[]>([])
+  const [loading, setLoading] = createSignal(true)
 
   let timeout: Timer | undefined
 

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -68,7 +68,7 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
       .finally(() => {
         if (!timeout) return
         setLoading(false)
-        timeout = setTimeout(fetch, 2000)
+        timeout = setTimeout(fetch, 1000)
       })
   }
 

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -59,6 +59,7 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
         setItems(
           reconcile(res.result?.map((item) => ({ ...item, ...parseUploadPath(item.url) })).sort((a, b) => b.progress - a.progress) || []),
         )
+        setError(undefined)
       })
       .catch((error) => {
         if (error instanceof Error && error.cause instanceof Response && error.cause.status === 404) {

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -4,6 +4,7 @@ import { UploadQueueItem } from '~/types'
 import LinearProgress from './material/LinearProgress'
 import Icon from './material/Icon'
 import { createStore, reconcile } from 'solid-js/store'
+import clsx from 'clsx'
 
 interface DecoratedUploadQueueItem extends UploadQueueItem {
   route: string
@@ -40,6 +41,8 @@ const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ ite
   )
 }
 
+const WAITING = 'Waiting for device to connect...'
+
 const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
   const [error, setError] = createSignal<string | undefined>()
   const [items, setItems] = createStore<DecoratedUploadQueueItem[]>([])
@@ -60,7 +63,7 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
       })
       .catch((error) => {
         if (error instanceof Error && error.cause instanceof Response && error.cause.status === 404) {
-          setError('Device offline')
+          setError(WAITING)
           return
         }
         setError(error.toString())
@@ -88,7 +91,7 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
               <Icon name="progress_activity" class="animate-spin" />
             </Match>
             <Match when={error()}>
-              <Icon name="error" />
+              <Icon class={clsx(error() === WAITING && 'animate-spin')} name={error() === WAITING ? 'progress_activity' : 'error'} />
               <span class="ml-2">{error()}</span>
             </Match>
             <Match when={items.length === 0}>

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -61,9 +61,9 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
       .catch((error) => {
         if (error instanceof Error && error.cause instanceof Response && error.cause.status === 404) {
           setError('Device offline')
-        } else {
-          setError(error.message)
+          return
         }
+        setError(error.toString())
       })
       .finally(() => {
         if (!timeout) return

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -1,0 +1,25 @@
+import { VoidComponent, createEffect } from 'solid-js'
+import { getUploadQueue } from '~/api/athena'
+import { createQuery } from '~/utils/createQuery'
+import StatisticBar from './StatisticBar'
+
+const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
+  const [queue] = createQuery({
+    source: () => props.dongleId,
+    fetcher: getUploadQueue,
+    refetchInterval: 2000,
+  })
+  createEffect(() => {
+    console.log(queue()?.result)
+  })
+  return (
+    <div class="flex flex-col border-2 border-t-0 border-surface-container-high bg-surface-container-lowest">
+      <div class="flex-auto p-4">
+        <StatisticBar statistics={[{ label: 'Total', value: () => queue()?.result?.length }]} />
+      </div>
+      <div class="rounded-md border-2 border-surface-container-high mx-4 mb-4 p-4"></div>
+    </div>
+  )
+}
+
+export default UploadQueue

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -88,16 +88,12 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
               <Icon name="progress_activity" class="animate-spin" />
             </Match>
             <Match when={error()}>
-              <div class="flex items-center gap-2">
-                <Icon name="error" />
-                <span>{error()}</span>
-              </div>
+              <Icon name="error" />
+              <span class="ml-2">{error()}</span>
             </Match>
             <Match when={items.length === 0}>
-              <div class="flex items-center gap-2">
-                <Icon name="check" />
-                <span>Nothing to upload</span>
-              </div>
+              <Icon name="check" />
+              <span class="ml-2">Nothing to upload</span>
             </Match>
             <Match when={true}>
               <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto hide-scrollbar">

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -16,30 +16,6 @@ const parseUploadPath = (url: string) => {
   return { route: parts[3], segment: parseInt(parts[4], 10), filename: parts[5] }
 }
 
-const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ item }) => {
-  return (
-    <div class="flex flex-col">
-      <div class={'flex items-center justify-between flex-wrap mb-1 gap-x-4 min-w-0'}>
-        <div class="flex items-center min-w-0 flex-1">
-          <Icon
-            class="text-on-surface-variant flex-shrink-0 mr-2"
-            name={item.priority === COMMA_CONNECT_PRIORITY ? 'person' : 'local_fire_department'}
-          />
-          <div class="flex min-w-0 gap-1">
-            <span class="text-body-sm font-mono truncate text-on-surface">{[item.route, item.segment, item.filename].join(' ')}</span>
-          </div>
-        </div>
-        <div class="flex items-center gap-2 flex-shrink-0 justify-end">
-          <span class="text-body-sm font-mono whitespace-nowrap">{Math.round(item.progress * 100)}%</span>
-        </div>
-      </div>
-      <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-container-highest">
-        <LinearProgress progress={item.progress} color={'primary'} />
-      </div>
-    </div>
-  )
-}
-
 const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
   const [loading, setLoading] = createSignal(true)
   const [items, setItems] = createStore<DecoratedUploadQueueItem[]>([])
@@ -97,7 +73,31 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
             </Match>
             <Match when={true}>
               <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto hide-scrollbar">
-                <For each={items}>{(item) => <UploadQueueRow item={item} />}</For>
+                <For each={items}>
+                  {(item) => (
+                    <div class="flex flex-col">
+                      <div class={'flex items-center justify-between flex-wrap mb-1 gap-x-4 min-w-0'}>
+                        <div class="flex items-center min-w-0 flex-1">
+                          <Icon
+                            class="text-on-surface-variant flex-shrink-0 mr-2"
+                            name={item.priority === COMMA_CONNECT_PRIORITY ? 'person' : 'local_fire_department'}
+                          />
+                          <div class="flex min-w-0 gap-1">
+                            <span class="text-body-sm font-mono truncate text-on-surface">
+                              {[item.route, item.segment, item.filename].join(' ')}
+                            </span>
+                          </div>
+                        </div>
+                        <div class="flex items-center gap-2 flex-shrink-0 justify-end">
+                          <span class="text-body-sm font-mono whitespace-nowrap">{Math.round(item.progress * 100)}%</span>
+                        </div>
+                      </div>
+                      <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-container-highest">
+                        <LinearProgress progress={item.progress} color={'primary'} />
+                      </div>
+                    </div>
+                  )}
+                </For>
               </div>
             </Match>
           </Switch>

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -13,11 +13,7 @@ interface DecoratedUploadQueueItem extends UploadQueueItem {
 
 const parseUploadPath = (url: string) => {
   const parts = new URL(url).pathname.split('/')
-  const route = parts[3]
-  const segment = parseInt(parts[4], 10)
-  const filename = parts[5]
-
-  return { route, segment, filename }
+  return { route: parts[3], segment: parseInt(parts[4], 10), filename: parts[5] }
 }
 
 const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ item }) => {
@@ -89,13 +85,19 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
         <div class="relative h-[calc(4*3rem)] sm:h-[calc(6*3rem)] flex justify-center items-center text-on-surface-variant">
           <Switch>
             <Match when={loading()}>
-              <span>Loading...</span>
+              <Icon name="progress_activity" class="animate-spin" />
             </Match>
             <Match when={error()}>
-              <span>{error()}</span>
+              <div class="flex items-center gap-2">
+                <Icon name="error" />
+                <span>{error()}</span>
+              </div>
             </Match>
             <Match when={items.length === 0}>
-              <span>Queue is empty</span>
+              <div class="flex items-center gap-2">
+                <Icon name="check" />
+                <span>Nothing to upload</span>
+              </div>
             </Match>
             <Match when={true}>
               <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto hide-scrollbar">

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -82,25 +82,24 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
   })
 
   return (
-    <div class="flex flex-col border-2 border-t-0 border-surface-container-high bg-surface-container-lowest">
-      <div class="flex flex-col flex-auto p-4 gap-4">
-        <div class="relative h-[calc(4*3rem)] sm:h-[calc(6*3rem)] flex justify-center items-center text-on-surface-variant">
-          <Switch>
-            <Match when={error()}>
-              <Icon class={clsx(error() === WAITING && 'animate-spin')} name={error() === WAITING ? 'progress_activity' : 'error'} />
-              <span class="ml-2">{error()}</span>
-            </Match>
-            <Match when={items.length === 0}>
-              <Icon name="check" />
-              <span class="ml-2">Nothing to upload</span>
-            </Match>
-            <Match when={true}>
-              <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto hide-scrollbar">
-                <For each={items}>{(item) => <UploadQueueRow item={item} />}</For>
-              </div>
-            </Match>
-          </Switch>
-        </div>
+    <div class="flex flex-col p-4 gap-4 bg-surface-container-lowest">
+      <div class="relative h-[calc(4*3rem)] sm:h-[calc(6*3rem)] flex justify-center items-center text-on-surface-variant">
+        <Switch
+          fallback={
+            <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto hide-scrollbar">
+              <For each={items}>{(item) => <UploadQueueRow item={item} />}</For>
+            </div>
+          }
+        >
+          <Match when={error()}>
+            <Icon class={clsx(error() === WAITING && 'animate-spin')} name={error() === WAITING ? 'progress_activity' : 'error'} />
+            <span class="ml-2">{error()}</span>
+          </Match>
+          <Match when={items.length === 0}>
+            <Icon name="check" />
+            <span class="ml-2">Nothing to upload</span>
+          </Match>
+        </Switch>
       </div>
     </div>
   )

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -35,7 +35,7 @@ const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ ite
         </div>
       </div>
       <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-container-highest">
-        <LinearProgress progress={item.progress} color="primary" />
+        <LinearProgress progress={item.progress} color={Math.round(item.progress * 100) === 100 ? 'tertiary' : 'primary'} />
       </div>
     </div>
   )

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -16,6 +16,30 @@ const parseUploadPath = (url: string) => {
   return { route: parts[3], segment: parseInt(parts[4], 10), filename: parts[5] }
 }
 
+const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ item }) => {
+  return (
+    <div class="flex flex-col">
+      <div class={'flex items-center justify-between flex-wrap mb-1 gap-x-4 min-w-0'}>
+        <div class="flex items-center min-w-0 flex-1">
+          <Icon
+            class="text-on-surface-variant flex-shrink-0 mr-2"
+            name={item.priority === COMMA_CONNECT_PRIORITY ? 'person' : 'local_fire_department'}
+          />
+          <div class="flex min-w-0 gap-1">
+            <span class="text-body-sm font-mono truncate text-on-surface">{[item.route, item.segment, item.filename].join(' ')}</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-2 flex-shrink-0 justify-end">
+          <span class="text-body-sm font-mono whitespace-nowrap">{Math.round(item.progress * 100)}%</span>
+        </div>
+      </div>
+      <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-container-highest">
+        <LinearProgress progress={item.progress} color={'primary'} />
+      </div>
+    </div>
+  )
+}
+
 const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
   const [loading, setLoading] = createSignal(true)
   const [items, setItems] = createStore<DecoratedUploadQueueItem[]>([])
@@ -73,31 +97,7 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
             </Match>
             <Match when={true}>
               <div class="absolute inset-0 flex flex-col gap-2 overflow-y-auto hide-scrollbar">
-                <For each={items}>
-                  {(item) => (
-                    <div class="flex flex-col">
-                      <div class={'flex items-center justify-between flex-wrap mb-1 gap-x-4 min-w-0'}>
-                        <div class="flex items-center min-w-0 flex-1">
-                          <Icon
-                            class="text-on-surface-variant flex-shrink-0 mr-2"
-                            name={item.priority === COMMA_CONNECT_PRIORITY ? 'person' : 'local_fire_department'}
-                          />
-                          <div class="flex min-w-0 gap-1">
-                            <span class="text-body-sm font-mono truncate text-on-surface">
-                              {[item.route, item.segment, item.filename].join(' ')}
-                            </span>
-                          </div>
-                        </div>
-                        <div class="flex items-center gap-2 flex-shrink-0 justify-end">
-                          <span class="text-body-sm font-mono whitespace-nowrap">{Math.round(item.progress * 100)}%</span>
-                        </div>
-                      </div>
-                      <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-container-highest">
-                        <LinearProgress progress={item.progress} color={'primary'} />
-                      </div>
-                    </div>
-                  )}
-                </For>
+                <For each={items}>{(item) => <UploadQueueRow item={item} />}</For>
               </div>
             </Match>
           </Switch>

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -19,7 +19,7 @@ const parseUploadPath = (url: string) => {
 const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ item }) => {
   return (
     <div class="flex flex-col">
-      <div class={'flex items-center justify-between flex-wrap mb-1 gap-x-4 min-w-0'}>
+      <div class="flex items-center justify-between flex-wrap mb-1 gap-x-4 min-w-0">
         <div class="flex items-center min-w-0 flex-1">
           <Icon
             class="text-on-surface-variant flex-shrink-0 mr-2"
@@ -34,7 +34,7 @@ const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ ite
         </div>
       </div>
       <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-container-highest">
-        <LinearProgress progress={item.progress} color={'primary'} />
+        <LinearProgress progress={item.progress} color="primary" />
       </div>
     </div>
   )

--- a/src/components/material/Icon.tsx
+++ b/src/components/material/Icon.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx'
 // biome-ignore format: the array should not be formatted
 export const Icons = [
   'add', 'arrow_back', 'camera', 'check', 'chevron_right', 'clear', 'close', 'delete', 'description', 'directions_car', 'download', 'error',
-  'file_copy', 'flag', 'info', 'logout', 'menu', 'my_location', 'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt',
+  'file_copy', 'flag', 'info', 'keyboard_arrow_down', 'keyboard_arrow_up', 'logout', 'menu', 'my_location', 'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt',
   'search', 'settings', 'sync', 'upload', 'videocam',
 ] as const
 

--- a/src/components/material/Icon.tsx
+++ b/src/components/material/Icon.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx'
 // biome-ignore format: the array should not be formatted
 export const Icons = [
   'add', 'arrow_back', 'camera', 'check', 'chevron_right', 'clear', 'close', 'delete', 'description', 'directions_car', 'download', 'error',
-  'file_copy', 'flag', 'info', 'keyboard_arrow_down', 'keyboard_arrow_up', 'logout', 'menu', 'my_location', 'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt',
+  'file_copy', 'flag', 'info', 'keyboard_arrow_down', 'keyboard_arrow_up', 'local_fire_department', 'logout', 'menu', 'my_location', 'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt',
   'search', 'settings', 'sync', 'upload', 'videocam',
 ] as const
 

--- a/src/components/material/Icon.tsx
+++ b/src/components/material/Icon.tsx
@@ -6,8 +6,8 @@ import clsx from 'clsx'
 // biome-ignore format: the array should not be formatted
 export const Icons = [
   'add', 'arrow_back', 'camera', 'check', 'chevron_right', 'clear', 'close', 'delete', 'description', 'directions_car', 'download', 'error',
-  'file_copy', 'flag', 'info', 'keyboard_arrow_down', 'keyboard_arrow_up', 'local_fire_department', 'logout', 'menu', 'my_location', 'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt',
-  'search', 'settings', 'sync', 'upload', 'videocam',
+  'file_copy', 'flag', 'info', 'keyboard_arrow_down', 'keyboard_arrow_up', 'local_fire_department', 'logout', 'menu', 'my_location', 
+  'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt', 'search', 'settings', 'sync', 'upload', 'videocam',
 ] as const
 
 export type IconName = (typeof Icons)[number]

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -128,8 +128,8 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
           </Show>
           <button
             class={clsx(
-              'flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/45',
-              queueVisible() ? 'border-2 border-t-0 border-surface-container-high' : '',
+              'flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2',
+              queueVisible() && 'border-t-2 border-t-surface-container-low',
             )}
             onClick={() => setQueueVisible(!queueVisible())}
           >

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { createResource, Suspense, createSignal, For, Show } from 'solid-js'
 import type { VoidComponent } from 'solid-js'
 
@@ -6,6 +7,7 @@ import { ATHENA_URL } from '~/api/config'
 import { getAccessToken } from '~/api/auth/client'
 
 import { DrawerToggleButton } from '~/components/material/Drawer'
+import Icon from '~/components/material/Icon'
 import IconButton from '~/components/material/IconButton'
 import TopAppBar from '~/components/material/TopAppBar'
 import DeviceLocation from '~/components/DeviceLocation'
@@ -13,6 +15,7 @@ import DeviceStatistics from '~/components/DeviceStatistics'
 import { getDeviceName } from '~/utils/device'
 
 import RouteList from '../components/RouteList'
+import UploadQueue from '~/components/UploadQueue'
 
 type DeviceActivityProps = {
   dongleId: string
@@ -28,6 +31,7 @@ interface SnapshotResponse {
 const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
   const [device] = createResource(() => props.dongleId, getDevice)
   const [deviceName] = createResource(device, getDeviceName)
+  const [queueVisible, setQueueVisible] = createSignal(false)
   const [snapshot, setSnapshot] = createSignal<{
     error: string | null
     fetching: boolean
@@ -119,6 +123,21 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
               <IconButton name="camera" onClick={() => void takeSnapshot()} />
             </div>
           </div>
+          <Show when={queueVisible()}>
+            <UploadQueue dongleId={props.dongleId} />
+          </Show>
+          <button
+            class={clsx(
+              'flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/45',
+              queueVisible() ? 'border-2 border-t-0 border-surface-container-high' : '',
+            )}
+            onClick={() => setQueueVisible(!queueVisible())}
+          >
+            <Icon
+              class={clsx(queueVisible() ? 'text-yellow-400' : 'text-zinc-500')}
+              name={queueVisible() ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+            />
+          </button>
         </div>
         <div class="flex flex-col gap-2">
           <For each={snapshot().images}>

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -133,10 +133,7 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
             )}
             onClick={() => setQueueVisible(!queueVisible())}
           >
-            <Icon
-              class={clsx(queueVisible() ? 'text-yellow-400' : 'text-zinc-500')}
-              name={queueVisible() ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
-            />
+            <Icon class="text-zinc-500" name={queueVisible() ? 'keyboard_arrow_up' : 'keyboard_arrow_down'} />
           </button>
         </div>
         <div class="flex flex-col gap-2">


### PR DESCRIPTION
last part of https://github.com/commaai/connect/issues/51

handles device disconnected, no items in queue, and rendering a list of files being uploaded

possible features to add in the future:
- nice animations
- displaying the offline queue
- simplify the polling loop with something like https://tanstack.com/query/latest/docs/framework/solid/overview