### PR TITLE
Fix pixelated flag icon border for certain screens

### DIFF
--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -47,7 +47,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
         trailing={
           <Suspense>
             <Show when={timeline()?.userFlags}>
-              <div class="flex items-center justify-center rounded-full bg-gradient-to-br from-amber-500 to-amber-900 p-2">
+              <div class="flex items-center justify-center rounded-full bg-gradient-to-br from-amber-500 to-amber-900 p-2 border border-amber-300 shadow-inner shadow-black/20">
                 <Icon class="text-yellow-300" size="20" name="flag" filled />
               </div>
             </Show>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -47,7 +47,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
         trailing={
           <Suspense>
             <Show when={timeline()?.userFlags}>
-              <div class="flex items-center justify-center rounded-full bg-gradient-to-br from-amber-500 to-amber-900 p-2 ring-1 ring-amber-300 shadow-inner shadow-black/20">
+              <div class="flex items-center justify-center rounded-full bg-gradient-to-br from-amber-500 to-amber-900 p-2">
                 <Icon class="text-yellow-300" size="20" name="flag" filled />
               </div>
             </Show>


### PR DESCRIPTION
- was using `ring-1` changed to `border`
- seems like it gets jaggedy and pixelated on certain screens
- using `border` better/consistent for lower DPI screens

From Shane:
![pixelated-flag](https://github.com/user-attachments/assets/6cf55720-c611-4f75-8ca8-3313f800721b)
