### PR TITLE
fix: use correct auth API endpoint

### DIFF
--- a/src/api/auth/client.ts
+++ b/src/api/auth/client.ts
@@ -4,7 +4,7 @@ const AUTH_KEY = 'ai.comma.api.authorization'
 
 export async function refreshAccessToken(code: string, provider: string): Promise<void> {
   try {
-    const resp = await fetch(`${BASE_URL}/v2/auth`, {
+    const resp = await fetch(`${BASE_URL}/v2/auth/`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
Fixes an issue related to CORS on stricter browsers (e.g. Safari)

Resolves #253 seen in #252