### PR TITLE
feat: poll offline queue

### DIFF
--- a/src/ci/check_bundle_size.ts
+++ b/src/ci/check_bundle_size.ts
@@ -30,7 +30,7 @@ const totalCompressedSizeKB = (totalCompressedSize / 1024).toFixed(2)
 files.push({}, { path: 'Total', sizeKB: totalSizeKB, compressedSizeKB: totalCompressedSizeKB })
 console.table(files, ['path', 'sizeKB', 'compressedSizeKB'])
 
-const upperBoundKB = 262
+const upperBoundKB = 263
 const lowerBoundKB = upperBoundKB - 10
 if (totalCompressedSize < lowerBoundKB * 1024) {
   console.warn(`Bundle size lower than expected, let's lower the limit! (${totalCompressedSizeKB}KB < ${lowerBoundKB}KB)`)

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -86,11 +86,7 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
           return
         }
         setItems(
-          reconcile(
-            res.result
-              ?.map((item) => ({ ...item, ...parseUploadPath(item.url), offline: false }))
-              .sort((a, b) => b.progress - a.progress) || [],
-          ),
+          reconcile(res.result?.map((item) => ({ ...item, ...parseUploadPath(item.url) })).sort((a, b) => b.progress - a.progress) || []),
         )
         setError(undefined)
       })

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Match, onCleanup, Show, Switch, VoidComponent } from 'solid-js'
+import { createSignal, For, Match, onCleanup, Switch, VoidComponent } from 'solid-js'
 import { COMMA_CONNECT_PRIORITY, getUploadQueue } from '~/api/athena'
 import { UploadFilesToUrlsRequest, UploadQueueItem } from '~/types'
 import LinearProgress from './material/LinearProgress'
@@ -33,9 +33,7 @@ const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ ite
           </div>
         </div>
         <div class="flex items-center gap-2 flex-shrink-0 justify-end">
-          <Show when={!item.offline} fallback={<span class="text-body-sm font-mono whitespace-nowrap">Queued</span>}>
-            <span class="text-body-sm font-mono whitespace-nowrap">{Math.round(item.progress * 100)}%</span>
-          </Show>
+          <span class="text-body-sm font-mono whitespace-nowrap">{item.offline ? 'Offline' : `${Math.round(item.progress * 100)}%`}</span>
         </div>
       </div>
       <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-container-highest">

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -11,7 +11,6 @@ interface DecoratedUploadQueueItem extends UploadQueueItem {
   route: string
   segment: number
   filename: string
-  offline: boolean
 }
 
 const parseUploadPath = (url: string) => {
@@ -33,7 +32,7 @@ const UploadQueueRow: VoidComponent<{ item: DecoratedUploadQueueItem }> = ({ ite
           </div>
         </div>
         <div class="flex items-center gap-2 flex-shrink-0 justify-end">
-          <span class="text-body-sm font-mono whitespace-nowrap">{item.offline ? 'Offline' : `${Math.round(item.progress * 100)}%`}</span>
+          <span class="text-body-sm font-mono whitespace-nowrap">{item.id ? `${Math.round(item.progress * 100)}%` : 'Offline'}</span>
         </div>
       </div>
       <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-container-highest">
@@ -69,10 +68,9 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
                   path: file.fn,
                   created_at: 0,
                   current: false,
-                  id: '0',
+                  id: '',
                   progress: 0,
                   retry_count: 0,
-                  offline: true,
                 }))
               }),
           ),

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -59,8 +59,7 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
             res
               .filter((r) => r.method === 'uploadFilesToUrls')
               .flatMap((item) => {
-                const params = item.params as UploadFilesToUrlsRequest
-                return params.files_data.map((file) => ({
+                return (item.params as UploadFilesToUrlsRequest).files_data.map((file) => ({
                   ...file,
                   ...parseUploadPath(file.url),
                   path: file.fn,

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -53,9 +53,7 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
   const fetch = () => {
     getAthenaOfflineQueue(props.dongleId)
       .then((res) => {
-        if (error() === undefined) {
-          return
-        }
+        if (!error()) return
         setItems(
           reconcile(
             res


### PR DESCRIPTION
https://github.com/commaai/connect/issues/51

tested locally:
1. when device offline, upload request puts items in offline queue, showing them in the queue in the UI with a "Queued" message
2. when device comes online, status switches to "Waiting" until Athena server pushes the queued requests
3. finally, messages start coming in and processing as normal