### PR TITLE
fix: auth / processing icons spin correct direction

### DIFF
--- a/src/components/material/Icon.tsx
+++ b/src/components/material/Icon.tsx
@@ -7,8 +7,8 @@ import clsx from 'clsx'
 export const Icons = [
   'add', 'arrow_back', 'camera', 'check', 'chevron_right', 'clear', 'close', 'delete', 'description', 'directions_car', 'download', 'error',
   'file_copy', 'flag', 'info', 'keyboard_arrow_down', 'keyboard_arrow_up', 'local_fire_department', 'logout', 'menu', 'my_location',
-  'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt', 'search', 'settings', 'sync', 'upload', 'videocam', 'refresh',
-  'login', 'person_off'
+  'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt', 'search', 'settings', 'upload', 'videocam', 'refresh',
+  'login', 'person_off', 'autorenew',
 ] as const
 
 export type IconName = (typeof Icons)[number]

--- a/src/pages/auth/auth.tsx
+++ b/src/pages/auth/auth.tsx
@@ -40,7 +40,7 @@ export default function Auth() {
           when={error()}
           fallback={
             <div class="flex items-center gap-3">
-              <Icon class="animate-spin" name="sync" size="24" />
+              <Icon class="animate-spin" name="progress_activity" size="24" />
               <p class="text-title-lg">authenticating</p>
             </div>
           }

--- a/src/pages/auth/auth.tsx
+++ b/src/pages/auth/auth.tsx
@@ -40,7 +40,7 @@ export default function Auth() {
           when={error()}
           fallback={
             <div class="flex items-center gap-3">
-              <Icon class="animate-spin" name="progress_activity" size="24" />
+              <Icon class="animate-spin" name="autorenew" size="24" />
               <p class="text-title-lg">authenticating</p>
             </div>
           }

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -305,7 +305,7 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
 
                 <Match when={paymentStatus === 'paid' && !subscription()}>
                   <div class="flex gap-2 rounded-sm bg-surface-container p-2 text-body-md text-on-surface">
-                    <Icon name="sync" size="20" />
+                    <Icon class="animate-spin" name="autorenew" size="20" />
                     Processing subscription...
                   </div>
                 </Match>


### PR DESCRIPTION
resolves: https://github.com/commaai/connect/issues/274

removed `sync` entirely because the `animate-spin` spins clockwise. instead of writing a custom animation, just using `autorenew` as it's essentially the same icon with arrows moving clockwise.

animating the processing subscription icon as well