### PR TITLE
Remove 1/2 duplicate route query

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,7 +9,6 @@ const populateFetchedAt = <T>(item: T): T => {
 }
 
 export async function fetcher<T>(endpoint: string, init?: RequestInit, apiUrl: string = BASE_URL): Promise<T> {
-  console.log("fetcher", endpoint)
   const res = await fetch(`${apiUrl}${endpoint}`, {
     ...init,
     headers: {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,6 +9,7 @@ const populateFetchedAt = <T>(item: T): T => {
 }
 
 export async function fetcher<T>(endpoint: string, init?: RequestInit, apiUrl: string = BASE_URL): Promise<T> {
+  console.log("fetcher", endpoint)
   const res = await fetch(`${apiUrl}${endpoint}`, {
     ...init,
     headers: {

--- a/src/components/RouteActions.tsx
+++ b/src/components/RouteActions.tsx
@@ -1,8 +1,9 @@
 import { createSignal, Show, type VoidComponent, createEffect, createResource } from 'solid-js'
 import clsx from 'clsx'
 
-import { setRoutePublic, setRoutePreserved, getPreservedRoutes, parseRouteName, getRoute } from '~/api/route'
+import { setRoutePublic, setRoutePreserved, getPreservedRoutes, parseRouteName } from '~/api/route'
 import Icon from '~/components/material/Icon'
+import type { Route } from '~/types'
 
 const ToggleButton: VoidComponent<{
   label: string
@@ -32,10 +33,10 @@ const ToggleButton: VoidComponent<{
 
 interface RouteActionsProps {
   routeName: string
+  route: Route | null
 }
 
 const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
-  const [routeResource] = createResource(() => props.routeName, getRoute)
   const [preservedRoutesResource] = createResource(() => parseRouteName(props.routeName).dongleId, getPreservedRoutes)
 
   const [isPublic, setIsPublic] = createSignal<boolean | undefined>(undefined)
@@ -44,14 +45,13 @@ const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
   const useradminUrl = () => `https://useradmin.comma.ai/?onebox=${currentRouteId()}`
 
   createEffect(() => {
-    const route = routeResource()
     const preservedRoutes = preservedRoutesResource()
-    if (!route) return
-    setIsPublic(route.is_public)
-    if (route.is_preserved) {
+    if (!props.route) return
+    setIsPublic(props.route.is_public)
+    if (props.route.is_preserved) {
       setIsPreserved(true)
     } else if (preservedRoutes) {
-      setIsPreserved(preservedRoutes.some((r) => r.fullname === route.fullname))
+      setIsPreserved(preservedRoutes.some((r) => r.fullname === props.route.fullname))
     } else {
       setIsPreserved(undefined)
     }

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -14,12 +14,15 @@ import RouteActions from '~/components/RouteActions'
 import RouteUploadButtons from '~/components/RouteUploadButtons'
 import Timeline from '~/components/Timeline'
 
+import type { Route } from '~/types'
+
 const RouteVideoPlayer = lazy(() => import('~/components/RouteVideoPlayer'))
 
 type RouteActivityProps = {
   dongleId: string
   dateStr: string
   startTime: number
+  route: Route | null
 }
 
 const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
@@ -65,7 +68,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
             <RouteStatistics class="p-5" route={route()} />
 
             <Suspense fallback={<div class="skeleton-loader min-h-48" />}>
-              <RouteActions routeName={routeName()} />
+              <RouteActions routeName={routeName()} route={route()} />
             </Suspense>
           </div>
         </div>

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -14,15 +14,12 @@ import RouteActions from '~/components/RouteActions'
 import RouteUploadButtons from '~/components/RouteUploadButtons'
 import Timeline from '~/components/Timeline'
 
-import type { Route } from '~/types'
-
 const RouteVideoPlayer = lazy(() => import('~/components/RouteVideoPlayer'))
 
 type RouteActivityProps = {
   dongleId: string
   dateStr: string
   startTime: number
-  route: Route | null
 }
 
 const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {


### PR DESCRIPTION
Ideally we only make one /route query when you load a route, not three. This PR removes one.

https://github.com/commaai/connect/pull/298#discussion_r2019681192