### PR TITLE
Fix routes not loading because one is missing events.json

### DIFF
--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -21,7 +21,12 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const endPosition = () => [props.route.end_lng || 0, props.route.end_lat || 0] as number[]
   const [startPlace] = createResource(startPosition, getPlaceName)
   const [endPlace] = createResource(endPosition, getPlaceName)
-  const [timeline] = createResource(() => props.route, getTimelineStatistics)
+  const [timeline] = createResource(() => props.route, (route) =>
+    getTimelineStatistics(route).catch((err) => {
+      console.error("Error fetching timeline for route", route.fullname, err);
+      return undefined;
+    }),
+  );
   const [location] = createResource(
     () => [startPlace(), endPlace()],
     ([startPlace, endPlace]) => {
@@ -68,7 +73,7 @@ type RouteListProps = {
 
 const RouteList: VoidComponent<RouteListProps> = (props) => {
   const dimensions = useDimensions()
-  const pageSize = () => Math.max(Math.ceil(dimensions().height / 2 / 140), 1)
+  const pageSize = () => 6;  // Math.max(Math.ceil(dimensions().height / 2 / 140), 1)
   const endpoint = () => `/v1/devices/${props.dongleId}/routes_segments?limit=${pageSize()}`
   const getKey = (previousPageData?: RouteSegments[]): string | undefined => {
     if (!previousPageData) return endpoint()

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -72,7 +72,7 @@ type RouteListProps = {
 
 const RouteList: VoidComponent<RouteListProps> = (props) => {
   const dimensions = useDimensions()
-  const pageSize = () => 6;  // Math.max(Math.ceil(dimensions().height / 2 / 140), 1)
+  const pageSize = () => Math.max(Math.ceil(dimensions().height / 2 / 140), 1)
   const endpoint = () => `/v1/devices/${props.dongleId}/routes_segments?limit=${pageSize()}`
   const getKey = (previousPageData?: RouteSegments[]): string | undefined => {
     if (!previousPageData) return endpoint()

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -25,8 +25,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
     getTimelineStatistics(route).catch((err) => {
       console.error("Error fetching timeline for route", route.fullname, err);
       return undefined;
-    }),
-  );
+    }));
   const [location] = createResource(
     () => [startPlace(), endPlace()],
     ([startPlace, endPlace]) => {

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -21,11 +21,14 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const endPosition = () => [props.route.end_lng || 0, props.route.end_lat || 0] as number[]
   const [startPlace] = createResource(startPosition, getPlaceName)
   const [endPlace] = createResource(endPosition, getPlaceName)
-  const [timeline] = createResource(() => props.route, (route) =>
-    getTimelineStatistics(route).catch((err) => {
-      console.error("Error fetching timeline for route", route.fullname, err);
-      return undefined;
-    }));
+  const [timeline] = createResource(
+    () => props.route,
+    (route) =>
+      getTimelineStatistics(route).catch((err) => {
+        console.error('Error fetching timeline for route', route.fullname, err)
+        return undefined
+      }),
+  )
   const [location] = createResource(
     () => [startPlace(), endPlace()],
     ([startPlace, endPlace]) => {


### PR DESCRIPTION
If there was an uncaught error, the Suspense would never get triggered and be stuck in fallback state forever

before:

![image](https://github.com/user-attachments/assets/9d2b3aa6-9aee-4505-aa0e-ce695d7069e5)

after:

![image](https://github.com/user-attachments/assets/e0fe7978-de09-46bd-ad87-19bc13d370ef)
