### PR TITLE
Handle errors for individual files

### DIFF
--- a/src/api/derived.ts
+++ b/src/api/derived.ts
@@ -82,7 +82,14 @@ const getDerived = <T>(route: Route, fn: string): Promise<T[]> => {
     const segmentNumbers = Array.from({ length: route.maxqlog }, (_, i) => i)
     urls = segmentNumbers.map((i) => `${route.url}/${i}/${fn}`)
   }
-  const results = urls.map((url) => fetch(url).then((res) => res.json() as T))
+  const results = urls.map((url) =>
+    fetch(url)
+      .then((res) => res.json() as T)
+      .catch((err) => {
+        console.error('Error fetching file', url, err)
+        return [] as unknown as T
+      }),
+  )
   return Promise.all(results)
 }
 

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -21,14 +21,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const endPosition = () => [props.route.end_lng || 0, props.route.end_lat || 0] as number[]
   const [startPlace] = createResource(startPosition, getPlaceName)
   const [endPlace] = createResource(endPosition, getPlaceName)
-  const [timeline] = createResource(
-    () => props.route,
-    (route) =>
-      getTimelineStatistics(route).catch((err) => {
-        console.error('Error fetching timeline for route', route.fullname, err)
-        return undefined
-      }),
-  )
+  const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(
     () => [startPlace(), endPlace()],
     ([startPlace, endPlace]) => {


### PR DESCRIPTION
Better version of https://github.com/commaai/connect/pull/311 that attempts to continue to use other available events files

Now the problem route in the other PR can be fully loaded:

![image](https://github.com/user-attachments/assets/dd6b7e73-09a2-4fa3-a9a0-d94d127d55a1)
