### PR TITLE
Revert "Remove duplicate events.json queries (#289)"

### DIFF
--- a/src/components/RouteStatistics.tsx
+++ b/src/components/RouteStatistics.tsx
@@ -1,6 +1,7 @@
+import { createResource } from 'solid-js'
 import type { VoidComponent } from 'solid-js'
 
-import { TimelineStatistics } from '~/api/derived'
+import { TimelineStatistics, getTimelineStatistics } from '~/api/derived'
 import type { Route } from '~/types'
 import { formatDistance, formatRouteDuration } from '~/utils/format'
 import StatisticBar from './StatisticBar'
@@ -11,14 +12,16 @@ const formatEngagement = (timeline?: TimelineStatistics): string | undefined => 
   return `${(100 * (engagedDuration / duration)).toFixed(0)}%`
 }
 
-const RouteStatistics: VoidComponent<{ class?: string; route?: Route | undefined; timeline?: TimelineStatistics }> = (props) => {
+const RouteStatistics: VoidComponent<{ class?: string; route?: Route | undefined }> = (props) => {
+  const [timeline] = createResource(() => props.route, getTimelineStatistics)
+
   return (
     <StatisticBar
       class={props.class}
       statistics={[
         { label: 'Distance', value: () => formatDistance(props.route?.length) },
         { label: 'Duration', value: () => (props.route ? formatRouteDuration(props.route) : undefined) },
-        { label: 'Engaged', value: () => formatEngagement(props.timeline) },
+        { label: 'Engaged', value: () => formatEngagement(timeline()) },
       ]}
     />
   )

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -56,7 +56,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       />
 
       <CardContent>
-        <RouteStatistics route={props.route} timeline={timeline()} />
+        <RouteStatistics route={props.route} />
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
This reverts commit fcd306d92ae87cfa9a542a359d041b15d428459b.

There was another instance of RouteStatistics that didn't set timeline.