### PR TITLE
feat: use device routes endpoint, rm route_segments

### DIFF
--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -103,14 +103,6 @@ export interface RouteShareSignature extends Record<string, string> {
   sig: string
 }
 
-export interface RouteSegments extends Route {
-  end_time_utc_millis: number
-  is_preserved: boolean
-  share_exp: RouteShareSignature['exp']
-  share_sig: RouteShareSignature['sig']
-  start_time_utc_millis: number
-}
-
 export interface Files {
   cameras: string[]
   dcameras: string[]

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -3,19 +3,19 @@ import dayjs from 'dayjs'
 
 import { fetcher } from '~/api'
 import { getTimelineStatistics } from '~/api/derived'
+import type { Route } from '~/api/types'
 import Card, { CardContent, CardHeader } from '~/components/material/Card'
 import Icon from '~/components/material/Icon'
 import RouteStatistics from '~/components/RouteStatistics'
 import { getPlaceName } from '~/map/geocode'
-import type { RouteSegments } from '~/api/types'
 
 interface RouteCardProps {
-  route: RouteSegments
+  route: Route
 }
 
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
-  const startTime = () => dayjs(props.route.start_time_utc_millis)
-  const endTime = () => dayjs(props.route.end_time_utc_millis)
+  const startTime = () => dayjs(props.route.start_time)
+  const endTime = () => dayjs(props.route.end_time)
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
@@ -75,24 +75,24 @@ const Sentinel = (props: { onTrigger: () => void }) => {
 const PAGE_SIZE = 10
 
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
-  const endpoint = () => `/v1/devices/${props.dongleId}/routes_segments?limit=${PAGE_SIZE}`
-  const getKey = (previousPageData?: RouteSegments[]): string | undefined => {
+  const endpoint = () => `/v1/devices/${props.dongleId}/routes?limit=${PAGE_SIZE}`
+  const getKey = (previousPageData?: Route[]): string | undefined => {
     if (!previousPageData) return endpoint()
     if (previousPageData.length === 0) return undefined
-    return `${endpoint()}&end=${previousPageData.at(-1)!.start_time_utc_millis - 1}`
+    return `${endpoint()}&created_before=${previousPageData.at(-1)!.create_time}`
   }
-  const getPage = (page: number): Promise<RouteSegments[]> => {
+  const getPage = (page: number): Promise<Route[]> => {
     if (pages[page] === undefined) {
       pages[page] = (async () => {
         const previousPageData = page > 0 ? await getPage(page - 1) : undefined
         const key = getKey(previousPageData)
-        return key ? fetcher<RouteSegments[]>(key) : []
+        return key ? fetcher<Route[]>(key) : []
       })()
     }
     return pages[page]
   }
 
-  const pages: Promise<RouteSegments[]>[] = []
+  const pages: Promise<Route[]>[] = []
   const [size, setSize] = createSignal(1)
   const pageNumbers = () => Array.from({ length: size() })
 


### PR DESCRIPTION
Endpoint supports listing timeless routes

Endpoint TODOs:
- [x] implement `created_before` param on routes endpoint
- [ ] fix demo routes
- [ ] include preserved routes

required for https://github.com/commaai/connect/issues/60