### PR TITLE
cleanup: return undefined for failed requests

### DIFF
--- a/src/api/derived.ts
+++ b/src/api/derived.ts
@@ -85,10 +85,10 @@ const getDerived = async <T>(route: Route, fn: string): Promise<T[]> => {
       .then((res) => res.json() as T)
       .catch((err) => {
         console.error('Error fetching file', url, err)
-        return null
+        return undefined
       }),
   )
-  return (await Promise.all(results)).filter((it) => it !== null)
+  return (await Promise.all(results)).filter((it) => it !== undefined)
 }
 
 export const getCoords = (route: Route): Promise<GPSPathPoint[]> =>

--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -49,11 +49,13 @@ export const getDevice = async (dongleId: string) => {
 }
 
 export const getAthenaOfflineQueue = async (dongleId: string) =>
-  fetcher<AthenaOfflineQueueResponse>(`/v1/devices/${dongleId}/athena_offline_queue`).catch(() => null)
+  fetcher<AthenaOfflineQueueResponse>(`/v1/devices/${dongleId}/athena_offline_queue`).catch(() => undefined)
 
-export const getDeviceLocation = async (dongleId: string) => fetcher<DeviceLocation>(`/v1/devices/${dongleId}/location`).catch(() => null)
+export const getDeviceLocation = async (dongleId: string) =>
+  fetcher<DeviceLocation>(`/v1/devices/${dongleId}/location`).catch(() => undefined)
 
-export const getDeviceStats = async (dongleId: string) => fetcher<DrivingStatistics>(`/v1.1/devices/${dongleId}/stats`).catch(() => null)
+export const getDeviceStats = async (dongleId: string) =>
+  fetcher<DrivingStatistics>(`/v1.1/devices/${dongleId}/stats`).catch(() => undefined)
 
 export const getDevices = async () =>
   fetcher<Device[]>('/v1/me/devices/')

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -2,4 +2,4 @@ import type { Profile } from '~/types'
 
 import { fetcher } from '.'
 
-export const getProfile = async () => fetcher<Profile>('/v1/me/').catch(() => null)
+export const getProfile = async () => fetcher<Profile>('/v1/me/').catch(() => undefined)

--- a/src/api/route.ts
+++ b/src/api/route.ts
@@ -8,7 +8,7 @@ export const parseRouteName = (routeName: string): RouteInfo => {
   return { dongleId, routeId }
 }
 
-export const getRoute = (routeName: Route['fullname']) => fetcher<Route>(`/v1/route/${routeName}/`).catch(() => null)
+export const getRoute = (routeName: Route['fullname']) => fetcher<Route>(`/v1/route/${routeName}/`).catch(() => undefined)
 
 export const getRouteShareSignature = (routeName: string) => fetcher<RouteShareSignature>(`/v1/route/${routeName}/share_signature`)
 
@@ -18,7 +18,7 @@ export const createQCameraStreamUrl = (routeName: Route['fullname'], signature: 
 export const getQCameraStreamUrl = (routeName: Route['fullname']) =>
   getRouteShareSignature(routeName)
     .then((signature) => createQCameraStreamUrl(routeName, signature))
-    .catch(() => null)
+    .catch(() => undefined)
 
 export const setRoutePublic = (routeName: string, isPublic: boolean): Promise<Route> =>
   fetcher<Route>(`/v1/route/${routeName}/`, {

--- a/src/components/DeviceLocation.tsx
+++ b/src/components/DeviceLocation.tsx
@@ -36,7 +36,7 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
   const [userPosition, setUserPosition] = createSignal<GeolocationPosition | null>(null)
   const [deviceLocation] = createResource(
     () => props.dongleId,
-    (dongleId: string) => getDeviceLocation(dongleId).catch(() => null),
+    (dongleId: string) => getDeviceLocation(dongleId).catch(() => undefined),
   )
 
   onMount(() => {

--- a/src/components/DeviceLocation.tsx
+++ b/src/components/DeviceLocation.tsx
@@ -36,7 +36,7 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
   const [userPosition, setUserPosition] = createSignal<GeolocationPosition | null>(null)
   const [deviceLocation] = createResource(
     () => props.dongleId,
-    (dongleId: string) => getDeviceLocation(dongleId).catch(() => undefined),
+    (dongleId) => getDeviceLocation(dongleId),
   )
 
   onMount(() => {

--- a/src/components/RouteActions.tsx
+++ b/src/components/RouteActions.tsx
@@ -33,7 +33,7 @@ const ToggleButton: VoidComponent<{
 
 interface RouteActionsProps {
   routeName: string
-  route: Route | undefined
+  route?: Route
 }
 
 const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
@@ -51,7 +51,8 @@ const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
     if (props.route.is_preserved) {
       setIsPreserved(true)
     } else if (preservedRoutes) {
-      setIsPreserved(preservedRoutes.some((r) => r.fullname === props.route.fullname))
+      const { fullname } = props.route
+      setIsPreserved(preservedRoutes.some((r) => r.fullname === fullname))
     } else {
       setIsPreserved(undefined)
     }

--- a/src/components/RouteUploadButtons.tsx
+++ b/src/components/RouteUploadButtons.tsx
@@ -50,7 +50,7 @@ const UploadButton: VoidComponent<UploadButtonProps> = (props) => {
 type ButtonType = 'cameras' | 'driver' | 'logs' | 'route'
 
 interface RouteUploadButtonsProps {
-  route: Route | undefined
+  route?: Route
 }
 
 const RouteUploadButtons: VoidComponent<RouteUploadButtonsProps> = (props) => {

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -6,9 +6,7 @@ import { TimelineEvent, getTimelineEvents } from '~/api/derived'
 import type { Route } from '~/types'
 import { getRouteDuration } from '~/utils/format'
 
-function renderTimelineEvents(route: Route | undefined, events: TimelineEvent[]) {
-  if (!route) return null
-
+function renderTimelineEvents(route: Route, events: TimelineEvent[]) {
   const duration = getRouteDuration(route)?.asMilliseconds() ?? 0
   return (
     <For each={events}>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -50,7 +50,7 @@ const DashboardDrawer: VoidComponent = () => {
           <Suspense fallback={<div class="min-h-16 rounded-md skeleton-loader" />}>
             <div class="flex max-w-full items-center px-3 rounded-md outline outline-1 outline-outline-variant min-h-16">
               <div class="shrink-0 size-10 inline-flex items-center justify-center rounded-full bg-primary-container text-on-primary-container">
-                <Icon name={profile.latest === null ? 'person_off' : 'person'} filled />
+                <Icon name={!profile.loading && !profile.latest ? 'person_off' : 'person'} filled />
               </div>
               <Show
                 when={profile()}
@@ -154,7 +154,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
             />
           )}
         </Match>
-        <Match when={profile() === null}>
+        <Match when={!profile.loading && !profile.latest}>
           <Navigate href="/login" />
         </Match>
         <Match when={getDefaultDongleId()} keyed>


### PR DESCRIPTION
This makes the code cleaner, although we should still look at adding ErrorBoundaries to show when an error has occurred