### PR TITLE
fix: hide cancel btn for in progress uploads, rework contrast

### DIFF
--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -42,10 +42,12 @@ const UploadQueueRow: VoidComponent<{ dongleId: string; item: DecoratedUploadQue
         </div>
         <div class="flex items-center gap-0.5 flex-shrink-0 justify-end">
           <Show
-            when={item.progress !== 0}
+            when={!item.id || item.progress !== 0}
             fallback={<IconButton class="text-red-300" size="20" name="close_small" onClick={() => cancel(dongleId, [item.id])} />}
           >
-            <span class="text-body-sm font-mono whitespace-nowrap pr-[0.5rem]">{`${Math.round(item.progress * 100)}%`}</span>
+            <span class="text-body-sm font-mono whitespace-nowrap pr-[0.5rem]">
+              {item.id ? `${Math.round(item.progress * 100)}%` : 'Offline'}
+            </span>
           </Show>
         </div>
       </div>

--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -41,9 +41,11 @@ const UploadQueueRow: VoidComponent<{ dongleId: string; item: DecoratedUploadQue
           </div>
         </div>
         <div class="flex items-center gap-0.5 flex-shrink-0 justify-end">
-          <span class="text-body-sm font-mono whitespace-nowrap">{item.id ? `${Math.round(item.progress * 100)}%` : 'Offline'}</span>
-          <Show when={item.id}>
-            <IconButton name="close_small" onClick={() => cancel(dongleId, [item.id])} />
+          <Show
+            when={item.progress !== 0}
+            fallback={<IconButton class="text-red-300" size="20" name="close_small" onClick={() => cancel(dongleId, [item.id])} />}
+          >
+            <span class="text-body-sm font-mono whitespace-nowrap pr-[0.5rem]">{`${Math.round(item.progress * 100)}%`}</span>
           </Show>
         </div>
       </div>


### PR DESCRIPTION
resolves: https://github.com/commaai/connect/issues/296

adding some contrast to the cancel btn as well, it blended in too well.

### offline
<img width="493" alt="image" src="https://github.com/user-attachments/assets/de04e3a4-6d35-41b8-96cc-aabb2ec41328" />

### online
<img width="504" alt="image" src="https://github.com/user-attachments/assets/b4eb95c0-ce8b-4284-99cb-5026f8885dc2" />
