### PR TITLE
cleanup: don't lazy import RouteVideoPlayer

### DIFF
--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -1,4 +1,4 @@
-import { createResource, createSignal, lazy, Suspense, type VoidComponent } from 'solid-js'
+import { createResource, createSignal, Suspense, type VoidComponent } from 'solid-js'
 
 import { setRouteViewed } from '~/api/athena'
 import { getDevice } from '~/api/devices'
@@ -8,13 +8,12 @@ import { dayjs } from '~/utils/format'
 
 import IconButton from '~/components/material/IconButton'
 import TopAppBar from '~/components/material/TopAppBar'
+import RouteActions from '~/components/RouteActions'
 import RouteStaticMap from '~/components/RouteStaticMap'
 import RouteStatistics from '~/components/RouteStatistics'
-import RouteActions from '~/components/RouteActions'
+import RouteVideoPlayer from '~/components/RouteVideoPlayer'
 import RouteUploadButtons from '~/components/RouteUploadButtons'
 import Timeline from '~/components/Timeline'
-
-const RouteVideoPlayer = lazy(() => import('~/components/RouteVideoPlayer'))
 
 type RouteActivityProps = {
   dongleId: string


### PR DESCRIPTION
very little benefit now that HLS.js is loaded lazily instead