### PR TITLE
ci: check TypeScript type errors

### DIFF
--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -22,7 +22,7 @@ const parseUploadPath = (url: string) => {
   if (parsed.hostname === 'upload.commadotai.com') {
     return { route: parts[2], segment: parseInt(parts[3], 10), filename: parts[4], isFirehose: true }
   }
-  return { route: parts[3], segment: parseInt(parts[4], 10), filename: parts[5], isFirehouse: false }
+  return { route: parts[3], segment: parseInt(parts[4], 10), filename: parts[5], isFirehose: false }
 }
 
 const cancel = (dongleId: string, ids: string[]) => {

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,7 @@ set -e
 
 bun install --frozen-lockfile
 bun biome ci
+bun tsc --noEmit
 bun playwright install
 bun run test run
 bun lines

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,8 @@
 set -e
 
 bun install --frozen-lockfile
-bun biome ci
 bun tsc --noEmit
+bun biome ci
 bun playwright install
 bun run test run
 bun lines

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,8 @@
 set -e
 
 bun install --frozen-lockfile
-bun tsc --noEmit
 bun biome ci
+bun tsc
 bun playwright install
 bun run test run
 bun lines

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "allowJs": true,
     "noEmit": true,
     "strict": true,
-    "types": ["vite/client", "bun"],
+    "types": ["vite/client", "bun", "vite-plugin-pwa/client"],
     "isolatedModules": true,
     "paths": {
       "~/*": ["./src/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "allowJs": true,
     "noEmit": true,
     "strict": true,
-    "types": ["vite/client", "bun", "vite-plugin-pwa/client"],
+    "types": ["bun", "vite/client", "vite-plugin-pwa/client"],
     "isolatedModules": true,
     "paths": {
       "~/*": ["./src/*"]


### PR DESCRIPTION
- run `tsc --noEmit` as a "type-checker" in the test suite (won't block the build if building works, so we can preview even if types aren't perfect)
- fix the two complaints