### PR TITLE
fix: concat usage

### DIFF
--- a/src/components/RouteUploadButtons.tsx
+++ b/src/components/RouteUploadButtons.tsx
@@ -91,12 +91,12 @@ const RouteUploadButtons: VoidComponent<RouteUploadButtonsProps> = (props) => {
     }
 
     const uploadButtonTypes: ButtonType[] = [type]
-    const uploadFileTypes: FileType[] = []
+    let uploadFileTypes: FileType[] = []
     for (const check of type === 'route' ? (['road', 'driver', 'logs'] as const) : [type]) {
       const state = uploadStore.states[check]
       if (state === 'loading' || state === 'success') continue
       uploadButtonTypes.push(check)
-      uploadFileTypes.concat(BUTTON_TO_FILE_TYPES[check])
+      uploadFileTypes = uploadFileTypes.concat(BUTTON_TO_FILE_TYPES[check])
     }
 
     updateButtonStates(uploadButtonTypes, 'loading')


### PR DESCRIPTION
introduced in https://github.com/commaai/connect/commit/0507b64e96f8009727ec871610e69353a1768676

buttons appear to not work but we aren't requesting any files types to upload when the helper is called

`concat()` does not modify underlying arrays