### PR TITLE
feat: Group cards by date

### DIFF
--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -37,11 +37,9 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
     <Card class="max-w-none" href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`} activeClass="md:before:bg-primary">
       <CardHeader
         headline={
-          <div class="flex gap-2">
-            <span>
-              {startTime().format('h:mm A')} to {endTime().format('h:mm A')}
-            </span>
-          </div>
+          <span>
+            {startTime().format('h:mm A')} to {endTime().format('h:mm A')}
+          </span>
         }
         subhead={location()}
         trailing={

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -41,7 +41,6 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
         <CardHeader
           headline={
             <div class="flex gap-2">
-              <span>{startTime().format('ddd, MMM D, YYYY')}</span>&middot;
               <span>
                 {startTime().format('h:mm A')} to {endTime().format('h:mm A')}
               </span>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -36,7 +36,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
 
   return (
     <>
-      {props.shouldShowDateHeader && <h2 class="text-lg font-medium mt-6 mb-2 px-2">{startTime().format('ddd, MMM D, YYYY')}</h2>}
+      {props.shouldShowDateHeader && <h2 class="text-xl font-bold mt-6 pl-2">{startTime().format('ddd, MMM D, YYYY')}</h2>}
       <Card class="max-w-none" href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`} activeClass="md:before:bg-primary">
         <CardHeader
           headline={

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -14,7 +14,7 @@ const renderedDateHeaders = new Set<string>()
 
 interface RouteCardProps {
   route: RouteSegments
-  showDateHeader: boolean
+  isFirstRouteOfDate: boolean
 }
 
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
@@ -37,7 +37,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
 
   return (
     <>
-      {props.showDateHeader && <h2 class="text-lg font-medium mt-6 mb-2 px-2">{startTime().format('ddd, MMM D, YYYY')}</h2>}
+      {props.isFirstRouteOfDate && <h2 class="text-lg font-medium mt-6 mb-2 px-2">{startTime().format('ddd, MMM D, YYYY')}</h2>}
       <Card class="max-w-none" href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`} activeClass="md:before:bg-primary">
         <CardHeader
           headline={
@@ -133,7 +133,7 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
                   const date = dayjs(route.start_time_utc_millis).format('YYYY-MM-DD')
                   const isFirstForDate = !renderedDateHeaders.has(date)
                   if (isFirstForDate) renderedDateHeaders.add(date)
-                  return <RouteCard route={route} showDateHeader={isFirstForDate} />
+                  return <RouteCard route={route} isFirstRouteOfDate={isFirstForDate} />
                 }}
               </For>
             </Suspense>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -114,7 +114,9 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
     if (shownDateHeaders.has(dateKey)) return null
 
     shownDateHeaders.add(dateKey)
-    return dayjs(route.start_time_utc_millis).format('ddd, MMM D, YYYY')
+
+    const date = dayjs(route.start_time_utc_millis)
+    return date.format(date.year() === dayjs().year() ? 'dddd, MMM D' : 'dddd, MMM D, YYYY')
   }
 
   let foundFirstDateHeader = false

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -117,7 +117,7 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
     return dayjs(route.start_time_utc_millis).format('ddd, MMM D, YYYY')
   }
 
-  let foundFirstHeader = false
+  let foundFirstDateHeader = false
 
   return (
     <div class="flex w-full flex-col justify-items-stretch gap-4">
@@ -132,14 +132,14 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
             >
               <For each={routes() || []}>
                 {(route) => {
-                  const headerText = getDateHeader(route)
-                  const isFirstHeader = headerText && !foundFirstHeader
-                  if (isFirstHeader) foundFirstHeader = true
+                  const dateHeaderText = getDateHeader(route)
+                  const isFirstDateHeader = dateHeaderText && !foundFirstDateHeader
+                  if (isFirstDateHeader) foundFirstDateHeader = true
 
                   return (
                     <>
-                      <Show when={headerText}>
-                        <h2 class={`text-xl font-bold pl-2 ${isFirstHeader ? '' : 'mt-6'}`}>{headerText}</h2>
+                      <Show when={dateHeaderText}>
+                        <h2 class={`text-xl font-bold pl-2 ${isFirstDateHeader ? '' : 'mt-6'}`}>{dateHeaderText}</h2>
                       </Show>
                       <RouteCard route={route} />
                     </>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -117,6 +117,8 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
     return dayjs(route.start_time_utc_millis).format('ddd, MMM D, YYYY')
   }
 
+  let foundFirstHeader = false
+
   return (
     <div class="flex w-full flex-col justify-items-stretch gap-4">
       <For each={pageNumbers()}>
@@ -131,10 +133,13 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
               <For each={routes() || []}>
                 {(route) => {
                   const headerText = getDateHeader(route)
+                  const isFirstHeader = headerText && !foundFirstHeader
+                  if (isFirstHeader) foundFirstHeader = true
+
                   return (
                     <>
                       <Show when={headerText}>
-                        <h2 class="text-xl font-bold mt-6 pl-2">{headerText}</h2>
+                        <h2 class={`text-xl font-bold pl-2 ${isFirstHeader ? '' : 'mt-6'}`}>{headerText}</h2>
                       </Show>
                       <RouteCard route={route} />
                     </>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -10,7 +10,7 @@ import { getPlaceName } from '~/map/geocode'
 import type { RouteSegments } from '~/types'
 
 // Track rendered dates at module level to persist between renders
-const seenDates = new Set<string>()
+const renderedDateHeaders = new Set<string>()
 
 interface RouteCardProps {
   route: RouteSegments
@@ -96,7 +96,7 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
     if (props.dongleId) {
       pages.length = 0
       setSize(1)
-      seenDates.clear() // Clear tracked dates when dongleId changes
+      renderedDateHeaders.clear()
     }
   })
 
@@ -131,8 +131,8 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
               <For each={routes() || []}>
                 {(route) => {
                   const date = dayjs(route.start_time_utc_millis).format('YYYY-MM-DD')
-                  const isFirstForDate = !seenDates.has(date)
-                  if (isFirstForDate) seenDates.add(date)
+                  const isFirstForDate = !renderedDateHeaders.has(date)
+                  if (isFirstForDate) renderedDateHeaders.add(date)
                   return <RouteCard route={route} showDateHeader={isFirstForDate} />
                 }}
               </For>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -9,12 +9,11 @@ import RouteStatistics from '~/components/RouteStatistics'
 import { getPlaceName } from '~/map/geocode'
 import type { RouteSegments } from '~/types'
 
-// Track rendered dates at module level to persist between renders
-const renderedDateHeaders = new Set<string>()
+const shownDateHeaders = new Set<string>()
 
 interface RouteCardProps {
   route: RouteSegments
-  isFirstRouteOfDate: boolean
+  shouldShowDateHeader: boolean
 }
 
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
@@ -37,7 +36,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
 
   return (
     <>
-      {props.isFirstRouteOfDate && <h2 class="text-lg font-medium mt-6 mb-2 px-2">{startTime().format('ddd, MMM D, YYYY')}</h2>}
+      {props.shouldShowDateHeader && <h2 class="text-lg font-medium mt-6 mb-2 px-2">{startTime().format('ddd, MMM D, YYYY')}</h2>}
       <Card class="max-w-none" href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`} activeClass="md:before:bg-primary">
         <CardHeader
           headline={
@@ -96,7 +95,7 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
     if (props.dongleId) {
       pages.length = 0
       setSize(1)
-      renderedDateHeaders.clear()
+      shownDateHeaders.clear()
     }
   })
 
@@ -130,10 +129,10 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
             >
               <For each={routes() || []}>
                 {(route) => {
-                  const date = dayjs(route.start_time_utc_millis).format('YYYY-MM-DD')
-                  const isFirstForDate = !renderedDateHeaders.has(date)
-                  if (isFirstForDate) renderedDateHeaders.add(date)
-                  return <RouteCard route={route} isFirstRouteOfDate={isFirstForDate} />
+                  const dateString = dayjs(route.start_time_utc_millis).format('YYYY-MM-DD')
+                  const isUniqueDate = !shownDateHeaders.has(dateString)
+                  if (isUniqueDate) shownDateHeaders.add(dateString)
+                  return <RouteCard route={route} shouldShowDateHeader={isUniqueDate} />
                 }}
               </For>
             </Suspense>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -60,7 +60,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   )
 }
 
-const PAGE_SIZE = 1
+const PAGE_SIZE = 10
 
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
   const endpoint = () => `/v1/devices/${props.dongleId}/routes_segments?limit=${PAGE_SIZE}`


### PR DESCRIPTION
My attempt on Shane's idea PR #310. <br>
I like this idea since it makes cards easier to read and also makes card thinner taking up less screen real estate. I avoided duplicate headers by tracking which date headers we've already shown in a persistent Set and only displaying a header when it's the first time we encounter that specific date. 
