### PR TITLE
test: include AppLayout in browser tests

### DIFF
--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -3,11 +3,11 @@ import { configure, render, waitFor } from '@solidjs/testing-library'
 
 import { clearAccessToken, setAccessToken } from '~/api/auth/client'
 import * as Demo from '~/api/auth/demo'
-import { Routes } from './App'
+import { AppLayout, Routes } from './App'
 
 const DEMO_LOG_ID = '000000dd--455f14369d'
 
-const renderApp = (location: string) => render(() => <Routes />, { location })
+const renderApp = (location: string) => render(() => <Routes />, { location, wrapper: AppLayout })
 
 beforeAll(() => configure({ asyncUtilTimeout: 2000 }))
 beforeEach(() => clearAccessToken())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,16 @@ const Dashboard = lazy(() => import('./pages/dashboard'))
 
 import OfflinePage from '~/pages/offline'
 
+export const Routes = () => (
+  <>
+    <Route path="/login" component={Login} />
+    <Route path="/logout" component={Logout} />
+    <Route path="/auth" component={Auth} />
+
+    <Route path="/*dongleId" component={Dashboard} />
+  </>
+)
+
 export const AppLayout: ParentComponent = (props) => {
   const [isOnline, setIsOnline] = createSignal(navigator.onLine)
   const handleOnline = () => setIsOnline(true)
@@ -27,16 +37,6 @@ export const AppLayout: ParentComponent = (props) => {
     </Show>
   )
 }
-
-export const Routes = () => (
-  <>
-    <Route path="/login" component={Login} />
-    <Route path="/logout" component={Logout} />
-    <Route path="/auth" component={Auth} />
-
-    <Route path="/*dongleId" component={Dashboard} />
-  </>
-)
 
 const App: VoidComponent = () => (
   <Router root={AppLayout}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, lazy, onCleanup, Show, Suspense, type VoidComponent } from 'solid-js'
+import { createSignal, lazy, onCleanup, Show, Suspense, type ParentComponent, type VoidComponent } from 'solid-js'
 import { Router, Route } from '@solidjs/router'
 import 'leaflet/dist/leaflet.css'
 
@@ -10,17 +10,7 @@ const Dashboard = lazy(() => import('./pages/dashboard'))
 
 import OfflinePage from '~/pages/offline'
 
-export const Routes = () => (
-  <>
-    <Route path="/login" component={Login} />
-    <Route path="/logout" component={Logout} />
-    <Route path="/auth" component={Auth} />
-
-    <Route path="/*dongleId" component={Dashboard} />
-  </>
-)
-
-const App: VoidComponent = () => {
+export const AppLayout: ParentComponent = (props) => {
   const [isOnline, setIsOnline] = createSignal(navigator.onLine)
   const handleOnline = () => setIsOnline(true)
   const handleOffline = () => setIsOnline(false)
@@ -33,11 +23,25 @@ const App: VoidComponent = () => {
 
   return (
     <Show when={isOnline()} fallback={<OfflinePage />}>
-      <Router root={(props) => <Suspense>{props.children}</Suspense>}>
-        <Routes />
-      </Router>
+      <Suspense>{props.children}</Suspense>
     </Show>
   )
 }
+
+export const Routes = () => (
+  <>
+    <Route path="/login" component={Login} />
+    <Route path="/logout" component={Logout} />
+    <Route path="/auth" component={Auth} />
+
+    <Route path="/*dongleId" component={Dashboard} />
+  </>
+)
+
+const App: VoidComponent = () => (
+  <Router root={AppLayout}>
+    <Routes />
+  </Router>
+)
 
 export default App


### PR DESCRIPTION
simulate the real app as closely as possible, important when we add more context providers like with TanStack Query

**Verification**
made sure tests fail when navigator.onLine is false, which causes elements to not render