### PR TITLE
Fix: Handle 'timeless' routes with missing start_time by using create_time and fallback UI

### DIFF
--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -36,10 +36,16 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       <CardHeader
         headline={
           <div class="flex gap-2">
-            <span>{startTime().format('ddd, MMM D, YYYY')}</span>&middot;
-            <span>
-              {startTime().format('h:mm A')} to {endTime().format('h:mm A')}
-            </span>
+            {props.route.start_time_utc_millis ? (
+              <>
+                <span>{startTime().format('ddd, MMM D, YYYY')}</span>&middot;
+                <span>
+                  {startTime().format('h:mm A')} to {endTime().format('h:mm A')}
+                </span>
+              </>
+            ) : (
+              <span>Timeless Route</span>
+            )}
           </div>
         }
         subhead={location()}
@@ -68,7 +74,7 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
   const getKey = (previousPageData?: RouteSegments[]): string | undefined => {
     if (!previousPageData) return endpoint()
     if (previousPageData.length === 0) return undefined
-    return `${endpoint()}&end=${previousPageData.at(-1)!.start_time_utc_millis - 1}`
+    return `${endpoint()}&end=${previousPageData.at(-1)!.create_time - 1}`
   }
   const getPage = (page: number): Promise<RouteSegments[]> => {
     if (pages[page] === undefined) {


### PR DESCRIPTION
Fixes #60

## Problem
Some routes were missing `start_time_utc_millis` due to devices booting without GPS/RTC sync. This caused the UI to display "Invalid Date" and potentially break pagination/sorting.

## What this PR does
- Replaces `start_time_utc_millis` with `create_time` in pagination logic
- Adds a fallback label: "Timeless Route" if no start time is present
- Verified UI does not crash and renders cleanly for routes without time

## Screenshots
Before: Invalid Date

<img width="1048" alt="Screenshot 2025-03-31 at 6 29 46 PM" src="https://github.com/user-attachments/assets/4a1d69cf-7a31-41f6-ae2b-34406183aa3a" />

After: Clean "Timeless Route" label

<img width="1111" alt="Screenshot 2025-03-31 at 6 29 26 PM" src="https://github.com/user-attachments/assets/9a14c6f7-3ea6-4beb-ada0-b2ce2f38c972" />

