### PR TITLE
RouteList: remove duplicate event.json queries

### DIFF
--- a/src/api/derived.ts
+++ b/src/api/derived.ts
@@ -77,7 +77,6 @@ export interface TimelineStatistics {
 }
 
 const getDerived = async <T>(route: Route, fn: string): Promise<T[]> => {
-  console.log('getDerived123', route.fullname, fn)
   if (!route) return []
   const segmentNumbers = Array.from({ length: route.maxqlog }, (_, i) => i)
   const urls = segmentNumbers.map((i) => `${route.url}/${i}/${fn}`)

--- a/src/api/derived.ts
+++ b/src/api/derived.ts
@@ -190,7 +190,7 @@ const generateTimelineEvents = (route: Route, events: DriveEvent[]): TimelineEve
 export const getTimelineEvents = (route: Route): Promise<TimelineEvent[]> =>
   getDriveEvents(route).then((events) => generateTimelineEvents(route, events))
 
-export const generateTimelineStatistics = (route: Route, timeline: TimelineEvent[]): TimelineStatistics => {
+export const generateTimelineStatistics = (route: Route | undefined, timeline: TimelineEvent[]): TimelineStatistics => {
   let engagedDuration = 0
   let userFlags = 0
   timeline.forEach((ev) => {

--- a/src/api/derived.ts
+++ b/src/api/derived.ts
@@ -94,7 +94,7 @@ const getDerived = async <T>(route: Route, fn: string): Promise<T[]> => {
 export const getCoords = (route: Route): Promise<GPSPathPoint[]> =>
   getDerived<GPSPathPoint[]>(route, 'coords.json').then((coords) => coords.flat())
 
-export const getDriveEvents = (route: Route): Promise<DriveEvent[]> =>
+const getDriveEvents = (route: Route): Promise<DriveEvent[]> =>
   getDerived<DriveEvent[]>(route, 'events.json').then((events) => events.flat())
 
 const generateTimelineEvents = (route: Route, events: DriveEvent[]): TimelineEvent[] => {
@@ -190,7 +190,7 @@ const generateTimelineEvents = (route: Route, events: DriveEvent[]): TimelineEve
 export const getTimelineEvents = (route: Route): Promise<TimelineEvent[]> =>
   getDriveEvents(route).then((events) => generateTimelineEvents(route, events))
 
-const generateTimelineStatistics = (route: Route, timeline: TimelineEvent[]): TimelineStatistics => {
+export const generateTimelineStatistics = (route: Route, timeline: TimelineEvent[]): TimelineStatistics => {
   let engagedDuration = 0
   let userFlags = 0
   timeline.forEach((ev) => {

--- a/src/api/derived.ts
+++ b/src/api/derived.ts
@@ -77,6 +77,7 @@ export interface TimelineStatistics {
 }
 
 const getDerived = async <T>(route: Route, fn: string): Promise<T[]> => {
+  console.log('getDerived', route.fullname, fn)
   if (!route) return []
   const segmentNumbers = Array.from({ length: route.maxqlog }, (_, i) => i)
   const urls = segmentNumbers.map((i) => `${route.url}/${i}/${fn}`)

--- a/src/api/derived.ts
+++ b/src/api/derived.ts
@@ -77,7 +77,6 @@ export interface TimelineStatistics {
 }
 
 const getDerived = async <T>(route: Route, fn: string): Promise<T[]> => {
-  console.log('getDerived', route.fullname, fn)
   if (!route) return []
   const segmentNumbers = Array.from({ length: route.maxqlog }, (_, i) => i)
   const urls = segmentNumbers.map((i) => `${route.url}/${i}/${fn}`)

--- a/src/api/derived.ts
+++ b/src/api/derived.ts
@@ -77,6 +77,7 @@ export interface TimelineStatistics {
 }
 
 const getDerived = async <T>(route: Route, fn: string): Promise<T[]> => {
+  console.log('getDerived123', route.fullname, fn)
   if (!route) return []
   const segmentNumbers = Array.from({ length: route.maxqlog }, (_, i) => i)
   const urls = segmentNumbers.map((i) => `${route.url}/${i}/${fn}`)

--- a/src/components/RouteStatistics.tsx
+++ b/src/components/RouteStatistics.tsx
@@ -11,7 +11,7 @@ const formatEngagement = (timeline?: TimelineStatistics): string | undefined => 
   return `${(100 * (engagedDuration / duration)).toFixed(0)}%`
 }
 
-const RouteStatistics: VoidComponent<{ class?: string; route?: Route; timeline?: TimelineStatistics }> = (props) => {
+const RouteStatistics: VoidComponent<{ class?: string; route: Route | undefined; timeline: TimelineStatistics | undefined }> = (props) => {
   return (
     <StatisticBar
       class={props.class}

--- a/src/components/RouteStatistics.tsx
+++ b/src/components/RouteStatistics.tsx
@@ -11,7 +11,7 @@ const formatEngagement = (timeline?: TimelineStatistics): string | undefined => 
   return `${(100 * (engagedDuration / duration)).toFixed(0)}%`
 }
 
-const RouteStatistics: VoidComponent<{ class?: string; route?: Route, timeline?: TimelineStatistics}> = (props) => {
+const RouteStatistics: VoidComponent<{ class?: string; route?: Route; timeline?: TimelineStatistics }> = (props) => {
   return (
     <StatisticBar
       class={props.class}

--- a/src/components/RouteStatistics.tsx
+++ b/src/components/RouteStatistics.tsx
@@ -1,7 +1,6 @@
-import { createResource } from 'solid-js'
 import type { VoidComponent } from 'solid-js'
 
-import { TimelineStatistics, getTimelineStatistics } from '~/api/derived'
+import type { TimelineStatistics } from '~/api/derived'
 import type { Route } from '~/api/types'
 import { formatDistance, formatRouteDuration } from '~/utils/format'
 import StatisticBar from './StatisticBar'
@@ -12,16 +11,14 @@ const formatEngagement = (timeline?: TimelineStatistics): string | undefined => 
   return `${(100 * (engagedDuration / duration)).toFixed(0)}%`
 }
 
-const RouteStatistics: VoidComponent<{ class?: string; route?: Route }> = (props) => {
-  const [timeline] = createResource(() => props.route, getTimelineStatistics)
-
+const RouteStatistics: VoidComponent<{ class?: string; route?: Route, timeline?: TimelineStatistics}> = (props) => {
   return (
     <StatisticBar
       class={props.class}
       statistics={[
         { label: 'Distance', value: () => formatDistance(props.route?.length) },
         { label: 'Duration', value: () => (props.route ? formatRouteDuration(props.route) : undefined) },
-        { label: 'Engaged', value: () => formatEngagement(timeline()) },
+        { label: 'Engaged', value: () => formatEngagement(props.timeline) },
       ]}
     />
   )

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -2,7 +2,7 @@ import { For, createResource, createSignal, createEffect, onMount, onCleanup, Su
 import type { VoidComponent } from 'solid-js'
 import clsx from 'clsx'
 
-import { TimelineEvent, getTimelineEvents } from '~/api/derived'
+import { TimelineEvent } from '~/api/derived'
 import type { Route } from '~/api/types'
 import { getRouteDuration } from '~/utils/format'
 
@@ -94,11 +94,11 @@ interface TimelineProps {
   route?: Route
   seekTime: number
   updateTime: (time: number) => void
+  events: TimelineEvent[]
 }
 
 const Timeline: VoidComponent<TimelineProps> = (props) => {
   const route = () => props.route
-  const [events] = createResource(route, getTimelineEvents, { initialValue: [] })
   // TODO: align to first camera frame event
   const [markerOffsetPct, setMarkerOffsetPct] = createSignal(0)
   const [duration] = createResource(route, (route) => getRouteDuration(route)?.asSeconds() ?? 0, { initialValue: 0 })
@@ -176,7 +176,7 @@ const Timeline: VoidComponent<TimelineProps> = (props) => {
         )}
         title="Disengaged"
       >
-        <Suspense fallback={<div class="skeleton-loader size-full"></div>}>{renderTimelineEvents(props.route, events())}</Suspense>
+        <Suspense fallback={<div class="skeleton-loader size-full"></div>}>{renderTimelineEvents(props.route, props.events)}</Suspense>
         <div
           class="absolute top-0 z-10 h-full"
           style={{

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -2,7 +2,7 @@ import { For, createResource, createSignal, createEffect, onMount, onCleanup, Su
 import type { VoidComponent } from 'solid-js'
 import clsx from 'clsx'
 
-import { TimelineEvent } from '~/api/derived'
+import type { TimelineEvent } from '~/api/derived'
 import type { Route } from '~/api/types'
 import { getRouteDuration } from '~/utils/format'
 

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -33,8 +33,8 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
 
   const [events] = createResource(route, getTimelineEvents, { initialValue: [] })
   const [timeline] = createResource(
-    () => route() && events() && ([route(), events()] as const),
-    ([r, e]) => generateTimelineStatistics(r, e),
+    () => [route(), events()] as const,
+    ([r, e]) => generateTimelineStatistics(r, e)
   )
 
   const onTimelineChange = (newTime: number) => {

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -34,7 +34,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
   const [events] = createResource(route, getTimelineEvents, { initialValue: [] })
   const [timeline] = createResource(
     () => [route(), events()] as const,
-    ([r, e]) => generateTimelineStatistics(r, e)
+    ([r, e]) => generateTimelineStatistics(r, e),
   )
 
   const onTimelineChange = (newTime: number) => {

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -64,15 +64,14 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
           <div class="flex flex-col gap-6 px-4 pb-4">
             <div class="flex flex-col">
               <RouteVideoPlayer ref={setVideoRef} routeName={routeName()} startTime={seekTime()} onProgress={setSeekTime} />
-              <Timeline class="mb-1" route={route.latest} seekTime={seekTime()} updateTime={onTimelineChange} events={events()} />{' '}
-              {/* Needs getTimelineEvents */}
+              <Timeline class="mb-1" route={route.latest} seekTime={seekTime()} updateTime={onTimelineChange} events={events()} />
             </div>
 
             <div class="flex flex-col gap-2">
               <h3 class="text-label-sm uppercase">Route Info</h3>
               <div class="flex flex-col rounded-md overflow-hidden bg-surface-container">
-                <RouteStatistics class="p-5" route={route()} timeline={timeline()} /> {/* Needs getTimelineStatistics */}
-                {/*<RouteStatistics class="p-5" route={route()} timeline={generateTimelineStatistics(route(), events())} /> /!* Needs getTimelineStatistics *!/*/}
+                <RouteStatistics class="p-5" route={route()} timeline={timeline()} />
+
                 <Suspense fallback={<div class="skeleton-loader min-h-48" />}>
                   <RouteActions routeName={routeName()} route={route()} />
                 </Suspense>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -52,7 +52,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       />
 
       <CardContent>
-        <RouteStatistics route={props.route} timeline={timeline()} /> {/* Needs getTimelineStatistics */}
+        <RouteStatistics route={props.route} timeline={timeline()} />
       </CardContent>
     </Card>
   )

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -72,7 +72,7 @@ const Sentinel = (props: { onTrigger: () => void }) => {
   return <div ref={sentinel} class="h-10 w-full" />
 }
 
-const PAGE_SIZE = 1
+const PAGE_SIZE = 10
 
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
   const endpoint = () => `/v1/devices/${props.dongleId}/routes_segments?limit=${PAGE_SIZE}`

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -52,7 +52,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       />
 
       <CardContent>
-        <RouteStatistics route={props.route} />
+        <RouteStatistics route={props.route} timeline={timeline()} />
       </CardContent>
     </Card>
   )
@@ -72,7 +72,7 @@ const Sentinel = (props: { onTrigger: () => void }) => {
   return <div ref={sentinel} class="h-10 w-full" />
 }
 
-const PAGE_SIZE = 10
+const PAGE_SIZE = 1
 
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
   const endpoint = () => `/v1/devices/${props.dongleId}/routes_segments?limit=${PAGE_SIZE}`

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -52,7 +52,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       />
 
       <CardContent>
-        <RouteStatistics route={props.route} timeline={timeline()} />
+        <RouteStatistics route={props.route} timeline={timeline()} /> {/* Needs getTimelineStatistics */}
       </CardContent>
     </Card>
   )

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -50,7 +50,7 @@ export const formatVideoTime = (seconds: number): string => {
   return `${minutes}:${remainingSeconds.padStart(2, '0')}`
 }
 
-export const getRouteDuration = (route: Route): Duration | undefined => {
+export const getRouteDuration = (route: Route | undefined): Duration | undefined => {
   if (!route || !route.end_time) return undefined
   const startTime = dayjs(route.start_time)
   const endTime = dayjs(route.end_time)


### PR DESCRIPTION
Split from https://github.com/commaai/connect/pull/392

Reduces the span of time we're spending on json queries for a route of 12 segs from 35ms to 10ms (from first query queue to last query start)