### PR TITLE
fix: correct path to Apple splash PWA assets

### DIFF
--- a/pwa-assets.config.ts
+++ b/pwa-assets.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
         basePath: '/',
         xhtml: true,
       },
+      name: (landscape, size) => {
+        // make sure to update when generating light/dark variants
+        return `apple-splash-${landscape ? 'landscape' : 'portrait'}-${size.width}x${size.height}.png`
+      },
     }),
   },
   images: ['public/favicon.svg'],


### PR DESCRIPTION
workaround a bug in the Vite PWA asset generator which included `-light` in the path to the image in `dist/index.html`, but the assets did not have `-light` in the filename.

closes #380