### PR TITLE
refactor: snappy route load - no suspense

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal, lazy, onCleanup, Show, Suspense, type ParentComponent, type VoidComponent } from 'solid-js'
+import { createSignal, lazy, onCleanup, Show, type ParentComponent, type VoidComponent } from 'solid-js'
 import { Router, Route } from '@solidjs/router'
 import { QueryClientProvider } from '@tanstack/solid-query'
 import { SolidQueryDevtools } from '@tanstack/solid-query-devtools'
@@ -37,7 +37,7 @@ export const AppLayout: ParentComponent = (props) => {
 
   return (
     <Show when={isOnline()} fallback={<OfflinePage />}>
-      <Suspense>{props.children}</Suspense>
+      {props.children}
     </Show>
   )
 }

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -50,11 +50,15 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
 
   return (
     <>
-      <TopAppBar leading={<IconButton class="md:hidden" name="arrow_back" href={`/${props.dongleId}`} />}>{startTime()}</TopAppBar>
+      <TopAppBar leading={<IconButton class="md:hidden" name="arrow_back" href={`/${props.dongleId}`} />}>
+        <Show when={startTime()} fallback={<div class="skeleton-loader min-h-16" />}>
+          {startTime()}
+        </Show>
+      </TopAppBar>
 
       <div class="flex flex-col gap-6 px-4 pb-4">
         <div class="flex flex-col">
-          <Show when={route.isSuccess && events.isSuccess} fallback={<div></div>}>
+          <Show when={route.isSuccess && events.isSuccess} fallback={<div class="skeleton-loader h-[335px]" />}>
             <RouteVideoPlayer ref={setVideoRef} routeName={routeName()} startTime={seekTime()} onProgress={setSeekTime} />
             <Timeline class="mb-1" route={route.data} seekTime={seekTime()} updateTime={onTimelineChange} events={events.data!} />
           </Show>


### PR DESCRIPTION
combined with https://github.com/commaai/connect/pull/446

routes load much faster

this is just to show how it works, the skeleton loaders are not right size and it needs extensive refactor (and could probably correctly leverage suspense)

not planning on merging