### PR TITLE
Revert shared device

### DIFF
--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -21,8 +21,8 @@ describe('Demo mode', () => {
   beforeEach(() => setAccessToken(Demo.ACCESS_TOKEN))
 
   test('View dashboard', async () => {
-    const { findAllByText } = renderApp('/')
-    expect(await findAllByText('demo 3X')).toHaveLength(2)
+    const { findByText } = renderApp('/')
+    expect(await findByText('demo 3X')).toBeTruthy()
   })
 
   test('View demo route', async () => {

--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -14,7 +14,39 @@ const sortDevices = (devices: Device[]) =>
     }
   })
 
-export const getDevice = async (dongleId: string) => fetcher<Device>(`/v1.1/devices/${dongleId}/`).catch(() => undefined)
+export const SHARED_DEVICE = 'Shared Device'
+
+const createSharedDevice = (dongleId: string): Device => ({
+  dongle_id: dongleId,
+  alias: SHARED_DEVICE,
+  serial: '',
+  last_athena_ping: 0,
+  ignore_uploads: null,
+  is_paired: true,
+  is_owner: false,
+  public_key: '',
+  prime: false,
+  prime_type: 0,
+  trial_claimed: false,
+  device_type: '',
+  openpilot_version: '',
+  sim_id: '',
+  sim_type: 0,
+  eligible_features: {
+    prime: false,
+    prime_data: false,
+    nav: false,
+  },
+  fetched_at: Math.floor(Date.now() / 1000),
+})
+
+export const getDevice = async (dongleId: string) => {
+  try {
+    return await fetcher<Device>(`/v1.1/devices/${dongleId}/`)
+  } catch {
+    return createSharedDevice(dongleId)
+  }
+}
 
 export const getAthenaOfflineQueue = (dongleId: string) =>
   fetcher<AthenaOfflineQueueResponse>(`/v1/devices/${dongleId}/athena_offline_queue`)

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -136,7 +136,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
         <Match when={urlState().dongleId} keyed>
           {(dongleId) => (
             <DashboardLayout
-              paneOne={<DeviceActivity dongleId={dongleId} device={currentDevice()} />}
+              paneOne={<DeviceActivity dongleId={dongleId} shared={!currentDevice()} />}
               paneTwo={
                 <Switch
                   fallback={
@@ -147,7 +147,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
                   }
                 >
                   <Match when={urlState().dateStr === 'settings' || urlState().dateStr === 'prime'}>
-                    <SettingsActivity dongleId={dongleId} />
+                    <SettingsActivity dongleId={dongleId} shared={!currentDevice()} />
                   </Match>
                   <Match when={urlState().dateStr}>
                     {(dateStr) => <RouteActivity dongleId={dongleId} dateStr={dateStr()} startTime={urlState().startTime} />}

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -116,8 +116,6 @@ const Dashboard: Component<RouteSectionProps> = () => {
   const [devices] = createResource(getDevices, { initialValue: [] })
   const [profile] = createResource(getProfile)
 
-  const currentDevice = () => devices()?.find((device) => device.dongle_id === urlState().dongleId)
-
   const getDefaultDongleId = () => {
     // Do not redirect if dongle ID already selected
     if (urlState().dongleId) return undefined
@@ -136,7 +134,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
         <Match when={urlState().dongleId} keyed>
           {(dongleId) => (
             <DashboardLayout
-              paneOne={<DeviceActivity dongleId={dongleId} shared={!currentDevice()} />}
+              paneOne={<DeviceActivity dongleId={dongleId} />}
               paneTwo={
                 <Switch
                   fallback={
@@ -147,7 +145,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
                   }
                 >
                   <Match when={urlState().dateStr === 'settings' || urlState().dateStr === 'prime'}>
-                    <SettingsActivity dongleId={dongleId} shared={!currentDevice()} />
+                    <SettingsActivity dongleId={dongleId} />
                   </Match>
                   <Match when={urlState().dateStr}>
                     {(dateStr) => <RouteActivity dongleId={dongleId} dateStr={dateStr()} startTime={urlState().startTime} />}

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx'
-import { createMemo, createResource, createSignal, For, Show, Suspense } from 'solid-js'
+import { createResource, createSignal, For, Show, Suspense } from 'solid-js'
 import type { VoidComponent } from 'solid-js'
 
-import { getDevice } from '~/api/devices'
+import { getDevice, SHARED_DEVICE } from '~/api/devices'
 import { ATHENA_URL } from '~/api/config'
 import { getAccessToken } from '~/api/auth/client'
 
@@ -19,7 +19,6 @@ import UploadQueue from '~/components/UploadQueue'
 
 type DeviceActivityProps = {
   dongleId: string
-  shared: boolean
 }
 
 interface SnapshotResponse {
@@ -32,7 +31,10 @@ interface SnapshotResponse {
 const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
   // TODO: device should be passed in from DeviceList
   const [device] = createResource(() => props.dongleId, getDevice)
-  const deviceName = createMemo(() => getDeviceName(device(), props.shared))
+  // Resource as source of another resource blocks component initialization
+  const deviceName = () => (device.latest ? getDeviceName(device.latest) : '')
+  // TODO: remove this. if we're listing the routes for a device you should always be a user, this is for viewing public routes which are being removed
+  const isDeviceUser = () => (device.loading ? true : device.latest?.is_owner || device.latest?.alias !== SHARED_DEVICE)
   const [queueVisible, setQueueVisible] = createSignal(false)
   const [snapshot, setSnapshot] = createSignal<{
     error: string | null
@@ -133,7 +135,7 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
               <IconButton name="settings" href={`/${props.dongleId}/settings`} />
             </div>
           </div>
-          <Show when={!props.shared}>
+          <Show when={isDeviceUser()}>
             <DeviceStatistics dongleId={props.dongleId} class="p-4" />
             <Show when={queueVisible()}>
               <UploadQueue dongleId={props.dongleId} />

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -34,7 +34,6 @@ const formatCurrency = (amount: number) => `$${(amount / 100).toFixed(amount % 1
 
 type PrimeActivityProps = {
   dongleId: string
-  shared: boolean
 }
 
 type PrimePlan = 'nodata' | 'data'
@@ -403,7 +402,7 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
 
 const SettingsActivity: VoidComponent<PrimeActivityProps> = (props) => {
   const [device] = createResource(() => props.dongleId, getDevice)
-  const deviceName = createMemo(() => getDeviceName(device(), props.shared))
+  const [deviceName] = createResource(device, getDeviceName)
 
   const [unpair, unpairData] = useAction(async () => {
     const { success } = await unpairDevice(props.dongleId)

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -34,6 +34,7 @@ const formatCurrency = (amount: number) => `$${(amount / 100).toFixed(amount % 1
 
 type PrimeActivityProps = {
   dongleId: string
+  shared: boolean
 }
 
 type PrimePlan = 'nodata' | 'data'
@@ -402,7 +403,7 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
 
 const SettingsActivity: VoidComponent<PrimeActivityProps> = (props) => {
   const [device] = createResource(() => props.dongleId, getDevice)
-  const deviceName = createMemo(() => getDeviceName(device()))
+  const deviceName = createMemo(() => getDeviceName(device(), props.shared))
 
   const [unpair, unpairData] = useAction(async () => {
     const { success } = await unpairDevice(props.dongleId)

--- a/src/pages/dashboard/components/DeviceList.tsx
+++ b/src/pages/dashboard/components/DeviceList.tsx
@@ -37,7 +37,7 @@ const DeviceList: VoidComponent<DeviceListProps> = (props) => {
               activeClass="before:bg-primary"
             >
               <ListItemContent
-                headline={getDeviceName(device, false)}
+                headline={getDeviceName(device)}
                 subhead={<span class="font-mono text-label-sm lowercase">{device.dongle_id}</span>}
               />
             </ListItem>

--- a/src/pages/dashboard/components/DeviceList.tsx
+++ b/src/pages/dashboard/components/DeviceList.tsx
@@ -37,7 +37,7 @@ const DeviceList: VoidComponent<DeviceListProps> = (props) => {
               activeClass="before:bg-primary"
             >
               <ListItemContent
-                headline={getDeviceName(device)}
+                headline={getDeviceName(device, false)}
                 subhead={<span class="font-mono text-label-sm lowercase">{device.dongle_id}</span>}
               />
             </ListItem>

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,10 +1,6 @@
 import type { Device } from '~/api/types'
 
-const SHARED_DEVICE = 'Shared Device'
-
-export function getDeviceName(device: Device | undefined, shared: boolean) {
-  if (shared) return SHARED_DEVICE
-  if (!device) return ''
+export function getDeviceName(device: Device) {
   if (device.alias) return device.alias
   return `comma ${device.device_type}`
 }

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -2,8 +2,9 @@ import type { Device } from '~/api/types'
 
 const SHARED_DEVICE = 'Shared Device'
 
-export function getDeviceName(device: Device | undefined) {
-  if (!device) return SHARED_DEVICE
+export function getDeviceName(device: Device | undefined, shared: boolean) {
+  if (shared) return SHARED_DEVICE
+  if (!device) return ''
   if (device.alias) return device.alias
   return `comma ${device.device_type}`
 }


### PR DESCRIPTION
Breaks the fallback where we need to differentiate between loading (undefined device) and actually denied/unknown/shared device (undefined device)