### PR TITLE
fix: RouteActivity suspense not blocking any longer

### DIFF
--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -145,8 +145,8 @@ const Dashboard: Component<RouteSectionProps> = () => {
                   <Match when={urlState().dateStr === 'settings' || urlState().dateStr === 'prime'}>
                     <SettingsActivity dongleId={dongleId} />
                   </Match>
-                  <Match when={urlState().dateStr}>
-                    {(dateStr) => <RouteActivity dongleId={dongleId} dateStr={dateStr()} startTime={urlState().startTime} />}
+                  <Match when={urlState().dateStr} keyed>
+                    {(dateStr) => <RouteActivity dongleId={dongleId} dateStr={dateStr} startTime={urlState().startTime} />}
                   </Match>
                 </Switch>
               }

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -65,7 +65,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
         <div class="flex flex-col gap-2">
           <h3 class="text-label-md uppercase">Route Info</h3>
           <div class="flex flex-col rounded-md overflow-hidden bg-surface-container">
-            <RouteStatistics class="p-5" route={route.latest} timeline={timeline()} />
+            <RouteStatistics class="p-5" route={route()} timeline={timeline()} />
 
             <RouteActions routeName={routeName()} route={route()} />
           </div>

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -59,7 +59,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
       <div class="flex flex-col gap-6 px-4 pb-4">
         <div class="flex flex-col">
           <RouteVideoPlayer ref={setVideoRef} routeName={routeName()} startTime={seekTime()} onProgress={setSeekTime} />
-          <Timeline class="mb-1" route={route.latest} seekTime={seekTime()} updateTime={onTimelineChange} events={events()} />
+          <Timeline class="mb-1" route={route()} seekTime={seekTime()} updateTime={onTimelineChange} events={events()} />
         </div>
 
         <div class="flex flex-col gap-2">


### PR DESCRIPTION
suspense works in RouteActivity now. `keyed` makes Solid re-render the component from scratch, so in this case the `RouteActivity` is re-rendered from scratch. i think the re-use between navigations was causing issues with resources in `RouteActivity`

we need `keyed` at the `dongleId` above for a similar reason.

i think it's technically an escape hatch, but we can spend time later on removing this.

need to rework RouteStatistics, engaged shows NaN% on immediate load

https://github.com/user-attachments/assets/bb0670c6-a869-4c22-a5c6-0be73582c4ac

