### PR TITLE
fix: reset the time/duration on new route

### DIFF
--- a/src/components/RouteVideoPlayer.tsx
+++ b/src/components/RouteVideoPlayer.tsx
@@ -126,6 +126,8 @@ const RouteVideoPlayer: VoidComponent<RouteVideoPlayerProps> = (props) => {
   // State reset on route change
   createEffect(() => {
     props.routeName // track changes
+    setCurrentTime(0)
+    setDuration(0)
     setVideoLoading(true)
     setErrored(false)
   })


### PR DESCRIPTION
think this may have gotten removed from https://github.com/commaai/connect/pull/428

we need to set the video player time back to zero on a route change

https://github.com/commaai/connect/pull/428/commits/c9915241ec97c31715e77b960aadafaebd588d3c