### PR TITLE
fix: show video unsupported error message

### DIFF
--- a/src/components/RouteVideoPlayer.tsx
+++ b/src/components/RouteVideoPlayer.tsx
@@ -15,6 +15,7 @@ type RouteVideoPlayerProps = {
 }
 
 const ERROR_MISSING_SEGMENT = 'This video segment has not uploaded yet or has been deleted.'
+const ERROR_UNSUPPORTED_BROWSER = 'This browser does not support Media Source Extensions API.'
 
 const RouteVideoPlayer: VoidComponent<RouteVideoPlayerProps> = (props) => {
   const routeName = () => props.routeName
@@ -132,6 +133,7 @@ const RouteVideoPlayer: VoidComponent<RouteVideoPlayerProps> = (props) => {
       setHls(null)
       if (!video.canPlayType('application/vnd.apple.mpegurl')) {
         console.error('Browser does not support Media Source Extensions API')
+        setErrorMessage(ERROR_UNSUPPORTED_BROWSER)
       }
     }
   })


### PR DESCRIPTION
Show an error when the browser can't play the video and doesn't support MSE (so we can't use Hls.js either), instead of just logging the error to the console