### PR TITLE
feat: color route card based on time

### DIFF
--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -17,7 +17,7 @@ interface RouteCardProps {
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs(props.route.start_time_utc_millis)
   const endTime = () => dayjs(props.route.end_time_utc_millis)
-  const color = () => dateToGradient(startTime().toDate(), '#f2c177', '#3b5273')
+  const color = () => dateToGradient(startTime().toDate(), '#fcd265', '#384d8f')
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -21,7 +21,8 @@ interface RouteCardProps {
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs.utc(props.route.start_time).local()
   const endTime = () => dayjs.utc(props.route.end_time).local()
-  const color = () => dateTimeToColorBetween(startTime().toDate(), '#4953de', '#ffc233')
+  // const color = () => dateTimeToColorBetween(startTime().toDate(), '#4953de', '#ffc233')
+  const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), '#12254E', '#ffc233')
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
@@ -57,7 +58,9 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       <CardContent>
         <RouteStatistics route={props.route} timeline={timeline()} />
       </CardContent>
-      <div class="h-2 w-full" style={{ background: color() }} />
+      {/*<div class="h-2 w-full" style={{ background: color() }} />*/}
+      <div class="h-2 w-full" style={{ background: `linear-gradient(in srgb to right, ${color().start} 0%, ${color().end} 100%)` }} />
+      {/*<div class="h-2 w-full" style='background: linear-gradient(in srgb to right, #12254E 40%, #ffc233 60%)' />*/}
     </Card>
   )
 }

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -21,8 +21,7 @@ interface RouteCardProps {
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs.utc(props.route.start_time).local()
   const endTime = () => dayjs.utc(props.route.end_time).local()
-  // const color = () => dateTimeToColorBetween(startTime().toDate(), '#4953de', '#ffc233')
-  const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), '#1E398A', '#DAA11C')
+  const color = () => dateTimeToColorBetween(startTime().toDate(), [30, 57, 138], [218, 161, 28])
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
@@ -58,9 +57,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       <CardContent>
         <RouteStatistics route={props.route} timeline={timeline()} />
       </CardContent>
-      {/*<div class="h-2 w-full" style={{ background: color() }} />*/}
-      <div class="h-2 w-full" style={{ background: `linear-gradient(in srgb to right, ${color().start} 0%, ${color().end} 100%)` }} />
-      {/*<div class="h-2 w-full" style='background: linear-gradient(in srgb to right, #12254E 40%, #ffc233 60%)' />*/}
+      <div class="h-2 w-full" style={{ background: color() }} />
     </Card>
   )
 }

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -81,7 +81,7 @@ const PAGE_SIZE = 10
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
   const endpoint = () => `/v1/devices/${props.dongleId}/routes?limit=${PAGE_SIZE}`
   const getKey = (previousPageData?: Route[]): string | undefined => {
-    if (!previousPageData) return endpoint() // `${endpoint()}&created_before=${1737949404}`
+    if (!previousPageData) return endpoint()
     if (previousPageData.length === 0) return undefined
     return `${endpoint()}&created_before=${previousPageData.at(-1)!.create_time}`
   }

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -22,7 +22,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs.utc(props.route.start_time).local()
   const endTime = () => dayjs.utc(props.route.end_time).local()
   // const color = () => dateTimeToColorBetween(startTime().toDate(), '#4953de', '#ffc233')
-  const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), '#12254E', '#ffc233')
+  const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), '#2341AC', '#ffc233')
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -84,7 +84,7 @@ const PAGE_SIZE = 10
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
   const endpoint = () => `/v1/devices/${props.dongleId}/routes?limit=${PAGE_SIZE}`
   const getKey = (previousPageData?: Route[]): string | undefined => {
-    if (!previousPageData) return `${endpoint()}&created_before=${1738113404}`
+    if (!previousPageData) return `${endpoint()}&created_before=${1737949404}`
     if (previousPageData.length === 0) return undefined
     return `${endpoint()}&created_before=${previousPageData.at(-1)!.create_time}`
   }

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -22,7 +22,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs.utc(props.route.start_time).local()
   const endTime = () => dayjs.utc(props.route.end_time).local()
   // const color = () => dateTimeToColorBetween(startTime().toDate(), '#4953de', '#ffc233')
-  const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), '#2341AC', '#ffc233')
+  const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), '#1E398A', '#ffc233')
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
@@ -84,7 +84,7 @@ const PAGE_SIZE = 10
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
   const endpoint = () => `/v1/devices/${props.dongleId}/routes?limit=${PAGE_SIZE}`
   const getKey = (previousPageData?: Route[]): string | undefined => {
-    if (!previousPageData) return endpoint()
+    if (!previousPageData) return `${endpoint()}&created_before=${1738113404}`
     if (previousPageData.length === 0) return undefined
     return `${endpoint()}&created_before=${previousPageData.at(-1)!.create_time}`
   }

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -8,7 +8,7 @@ import Icon from '~/components/material/Icon'
 import RouteStatistics from '~/components/RouteStatistics'
 import { getPlaceName } from '~/map/geocode'
 import type { RouteSegments } from '~/api/types'
-import { dateToGradient } from '~/utils/format'
+import { dateTimeToColorBetween } from '~/utils/format'
 
 interface RouteCardProps {
   route: RouteSegments
@@ -17,7 +17,7 @@ interface RouteCardProps {
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs(props.route.start_time_utc_millis)
   const endTime = () => dayjs(props.route.end_time_utc_millis)
-  const color = () => dateToGradient(startTime().toDate(), '#fcd265', '#384d8f')
+  const color = () => dateTimeToColorBetween(startTime().toDate(), '#4953de', '#ffc233')
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -22,7 +22,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs.utc(props.route.start_time).local()
   const endTime = () => dayjs.utc(props.route.end_time).local()
   // const color = () => dateTimeToColorBetween(startTime().toDate(), '#4953de', '#ffc233')
-  const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), '#1E398A', '#ffc233')
+  const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), '#1E398A', '#DAA11C')
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
@@ -84,7 +84,7 @@ const PAGE_SIZE = 10
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
   const endpoint = () => `/v1/devices/${props.dongleId}/routes?limit=${PAGE_SIZE}`
   const getKey = (previousPageData?: Route[]): string | undefined => {
-    if (!previousPageData) return `${endpoint()}&created_before=${1737949404}`
+    if (!previousPageData) return endpoint() // `${endpoint()}&created_before=${1737949404}`
     if (previousPageData.length === 0) return undefined
     return `${endpoint()}&created_before=${previousPageData.at(-1)!.create_time}`
   }

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -8,6 +8,7 @@ import Icon from '~/components/material/Icon'
 import RouteStatistics from '~/components/RouteStatistics'
 import { getPlaceName } from '~/map/geocode'
 import type { RouteSegments } from '~/api/types'
+import { dateToGradient } from '~/utils/format'
 
 interface RouteCardProps {
   route: RouteSegments
@@ -16,6 +17,7 @@ interface RouteCardProps {
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs(props.route.start_time_utc_millis)
   const endTime = () => dayjs(props.route.end_time_utc_millis)
+  const color = () => dateToGradient(startTime().toDate(), '#f2c177', '#3b5273')
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
@@ -51,6 +53,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       <CardContent>
         <RouteStatistics route={props.route} timeline={timeline()} />
       </CardContent>
+      <div class="h-2 w-full" style={{ background: color() }} />
     </Card>
   )
 }

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -56,8 +56,8 @@ describe('formatDate', () => {
 describe('dateToGradient', () => {
   it('should generate gradients', () => {
     expect(dateToGradient(new Date('2025-02-01T00:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#384d8f')
-    expect(dateToGradient(new Date('2025-02-01T06:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#9a8f7a')
+    expect(dateToGradient(new Date('2025-02-01T06:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#fcd265')
     expect(dateToGradient(new Date('2025-02-01T12:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#fcd265')
-    expect(dateToGradient(new Date('2025-02-01T18:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#9a907a')
+    expect(dateToGradient(new Date('2025-02-01T18:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#384d8f')
   })
 })

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -55,9 +55,9 @@ describe('formatDate', () => {
 
 describe('dateTimeToColorBetween', () => {
   it('should generate a color between two colors', () => {
-    expect(dateTimeToColorBetween(new Date('2025-02-01T00:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#fcd265')
-    expect(dateTimeToColorBetween(new Date('2025-02-01T06:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#9a907a')
-    expect(dateTimeToColorBetween(new Date('2025-02-01T12:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#384d8f')
-    expect(dateTimeToColorBetween(new Date('2025-02-01T18:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#9a907a')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T00:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(30, 57, 138)')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T06:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(124, 109, 83)')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T12:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(218, 161, 28)')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T18:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(218, 161, 28)')
   })
 })

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { dateToGradient, formatDate, formatDistance, formatDuration } from './format'
+import { dateTimeToColorBetween, formatDate, formatDistance, formatDuration } from './format'
 
 describe('formatDistance', () => {
   it('should format distance', () => {
@@ -53,15 +53,11 @@ describe('formatDate', () => {
   })
 })
 
-describe('dateToGradient', () => {
-  it('should generate gradients', () => {
-    expect(dateToGradient(new Date('2025-02-01T00:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#384d8f')
-    expect(dateToGradient(new Date('2025-02-01T06:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#fcd265')
-    expect(dateToGradient(new Date('2025-02-01T12:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#fcd265')
-    expect(dateToGradient(new Date('2025-02-01T18:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#384d8f')
-  })
-
-  it('should fail to generate gradients', () => {
-    expect(() => dateToGradient(new Date('2025-02-01T00:00:00.000Z'), '#fcd', '#38f')).toThrow()
+describe('dateTimeToColorBetween', () => {
+  it('should generate a color between two colors', () => {
+    expect(dateTimeToColorBetween(new Date('2025-02-01T00:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#fcd265')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T06:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#9a907a')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T12:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#384d8f')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T18:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#9a907a')
   })
 })

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -60,4 +60,9 @@ describe('dateToGradient', () => {
     expect(dateToGradient(new Date('2025-02-01T12:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#fcd265')
     expect(dateToGradient(new Date('2025-02-01T18:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#384d8f')
   })
+
+  it('should fail to generate gradients', () => {
+    expect(() => dateToGradient(new Date('2025-02-01T00:00:00.000Z'), '#fcd', '#38f')).toThrow()
+    expect(() => dateToGradient(new Date('2025-02-01T00:00:00.000Z'), '#fcd', '#38f')).toThrow()
+  })
 })

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -58,6 +58,6 @@ describe('dateTimeToColorBetween', () => {
     expect(dateTimeToColorBetween(new Date('2025-02-01T00:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(30, 57, 138)')
     expect(dateTimeToColorBetween(new Date('2025-02-01T06:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(124, 109, 83)')
     expect(dateTimeToColorBetween(new Date('2025-02-01T12:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(218, 161, 28)')
-    expect(dateTimeToColorBetween(new Date('2025-02-01T18:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(218, 161, 28)')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T18:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(124, 109, 83)')
   })
 })

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -63,6 +63,5 @@ describe('dateToGradient', () => {
 
   it('should fail to generate gradients', () => {
     expect(() => dateToGradient(new Date('2025-02-01T00:00:00.000Z'), '#fcd', '#38f')).toThrow()
-    expect(() => dateToGradient(new Date('2025-02-01T00:00:00.000Z'), '#fcd', '#38f')).toThrow()
   })
 })

--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { formatDate, formatDistance, formatDuration } from './format'
+import { dateToGradient, formatDate, formatDistance, formatDuration } from './format'
 
 describe('formatDistance', () => {
   it('should format distance', () => {
@@ -50,5 +50,14 @@ describe('formatDate', () => {
     expect(formatDate(1482652800)).toBe('December 25th, 2016')
     expect(formatDate(1738943059)).toBe('February 7th')
     expect(formatDate(1738943059000)).toBe('February 7th')
+  })
+})
+
+describe('dateToGradient', () => {
+  it('should generate gradients', () => {
+    expect(dateToGradient(new Date('2025-02-01T00:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#384d8f')
+    expect(dateToGradient(new Date('2025-02-01T06:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#9a8f7a')
+    expect(dateToGradient(new Date('2025-02-01T12:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#fcd265')
+    expect(dateToGradient(new Date('2025-02-01T18:00:00.000Z'), '#fcd265', '#384d8f')).toBe('#9a907a')
   })
 })

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -80,7 +80,7 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 
 export const dateTimeToColorBetween = (startTime: Date, startColor: number[], endColor: number[]): string => {
   const sunrise = 5 // hours
-  const sunset = 6 + 12
+  const sunset = 5 + 12
   const fade = 2
 
   const hours = startTime.getHours() + startTime.getMinutes() / 60

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -89,7 +89,7 @@ const rgbToHex = (rgb: [number, number, number]): string => '#' + rgb.map((v) =>
 
 const blend = (a: number, b: number, mix: number): number => Math.round(a * mix + b * (1 - mix))
 
-export const dateToGradient = (date: Date, colorA: string, colorB: string, centerHour = 9, power = 6): string => {
+export const dateToGradient = (date: Date, colorA: string, colorB: string, centerHour = 12, power = 6): string => {
   const [r1, g1, b1] = hexToRgb(colorA)
   const [r2, g2, b2] = hexToRgb(colorB)
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -81,7 +81,7 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 export const dateTimeToColorBetween = (startTime: Date, startColor: number[], endColor: number[]): string => {
   const sunrise = 5 // hours
   const sunset = 5 + 12
-  const fade = 2 // wide transition since this accounts for varying daylight
+  const fade = 2 // wide transition since this accounts for different seasons
 
   const hours = startTime.getHours() + startTime.getMinutes() / 60
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -87,7 +87,7 @@ const hexToRgb = (hex: string): [number, number, number] => {
 
 const rgbToHex = (rgb: [number, number, number]): string => '#' + rgb.map((v) => v.toString(16).padStart(2, '0')).join('')
 
-const blendChannel = (a: number, b: number, mix: number): number => Math.round(a * mix + b * (1 - mix))
+const blend = (a: number, b: number, mix: number): number => Math.round(a * mix + b * (1 - mix))
 
 export const dateToGradient = (date: Date, colorA: string, colorB: string, centerHour = 9): string => {
   const [r1, g1, b1] = hexToRgb(colorA)
@@ -102,7 +102,5 @@ export const dateToGradient = (date: Date, colorA: string, colorB: string, cente
   const theta = t * 2 * Math.PI
   const mix = (1 + Math.cos(theta)) / 2
 
-  const rgb: [number, number, number] = [blendChannel(r1, r2, mix), blendChannel(g1, g2, mix), blendChannel(b1, b2, mix)]
-
-  return rgbToHex(rgb)
+  return rgbToHex([blend(r1, r2, mix), blend(g1, g2, mix), blend(b1, b2, mix)])
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -79,9 +79,10 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 }
 
 function l(t: number) {
+  t = t + 1
   const startTime = 6.5
   const endTime = 6 + 12
-  const fadeHours = 1
+  const fadeHours = 0.5
   if ((startTime < t) && (t < (startTime + fadeHours))) return (t - startTime) / fadeHours
   if ((endTime < t) && (t < (endTime + fadeHours))) return 1 - (t - endTime) / fadeHours
   if ((startTime < t) && (t < (endTime + fadeHours))) return 1

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -77,3 +77,32 @@ export const formatDate = (input: dayjs.ConfigType): string => {
   const yearStr = date.year() === dayjs().year() ? '' : ', YYYY'
   return date.format('MMMM Do' + yearStr)
 }
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  hex = hex.replace('#', '')
+  if (hex.length !== 6) throw new Error('Invalid hex color')
+  const [r, g, b] = [parseInt(hex.slice(0, 2), 16), parseInt(hex.slice(2, 4), 16), parseInt(hex.slice(4, 6), 16)]
+  return [r, g, b]
+}
+
+const rgbToHex = (rgb: [number, number, number]): string => '#' + rgb.map((v) => v.toString(16).padStart(2, '0')).join('')
+
+const blendChannel = (a: number, b: number, mix: number): number => Math.round(a * mix + b * (1 - mix))
+
+export const dateToGradient = (date: Date, colorA: string, colorB: string, centerHour = 9): string => {
+  const [r1, g1, b1] = hexToRgb(colorA)
+  const [r2, g2, b2] = hexToRgb(colorB)
+
+  const hours = date.getHours() + date.getMinutes() / 60
+
+  // normalize time so that centerHour is 0 and wraps around 24 hours
+  const t = ((hours - centerHour + 24) % 24) / 24
+
+  // cosine smooths transition between colorA and colorB
+  const theta = t * 2 * Math.PI
+  const mix = (1 + Math.cos(theta)) / 2
+
+  const rgb: [number, number, number] = [blendChannel(r1, r2, mix), blendChannel(g1, g2, mix), blendChannel(b1, b2, mix)]
+
+  return rgbToHex(rgb)
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -86,9 +86,11 @@ export const dateTimeToColorBetween = (startTime: Date, startColor: number[], en
   const hours = startTime.getHours() + startTime.getMinutes() / 60
 
   let blendFactor = 0
-  if (fadeStart < hours && hours < fadeStart + fade) blendFactor = (hours - fadeStart) / fade
-  else if (fadeEnd < hours && hours < fadeEnd + fade) blendFactor = 1 - (hours - fadeEnd) / fade
-  else if (fadeStart < hours && hours < fadeEnd + fade) blendFactor = 1
+  if (fadeStart < hours && hours < fadeEnd) {
+    blendFactor = Math.min((hours - fadeStart) / fade, 1)
+  } else if (fadeEnd <= hours) {
+    blendFactor = Math.max(1 - (hours - fadeEnd) / fade, 0)
+  }
 
   const blended = startColor.map((c, i) => c + (endColor[i] - c) * blendFactor)
   return `rgb(${blended.join(', ')})`

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -79,16 +79,16 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 }
 
 export const dateTimeToColorBetween = (startTime: Date, startColor: number[], endColor: number[]): string => {
-  const sunrise = 6.5 // safe estimate year-round
-  const sunset = 6 + 12 // FIXME: average is 6:30, but it's better to false positive night than day
-  const twilight = 0.5 // civil twilight is when it gets dark
+  const fadeStart = 5  // hours
+  const fadeEnd = 6 + 12
+  const fade = 2
 
   const hours = startTime.getHours() + startTime.getMinutes() / 60
 
   let blendFactor = 0
-  if (sunrise < hours && hours < sunrise + twilight) blendFactor = (hours - sunrise) / twilight
-  else if (sunset < hours && hours < sunset + twilight) blendFactor = 1 - (hours - sunset) / twilight
-  else if (sunrise < hours && hours < sunset + twilight) blendFactor = 1
+  if (fadeStart < hours && hours < fadeStart + fade) blendFactor = (hours - fadeStart) / fade
+  else if (fadeEnd < hours && hours < fadeEnd + fade) blendFactor = 1 - (hours - fadeEnd) / fade
+  else if (fadeStart < hours && hours < fadeEnd + fade) blendFactor = 1
 
   const blended = startColor.map((c, i) => c + (endColor[i] - c) * blendFactor)
   return `rgb(${blended.join(', ')})`

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -81,7 +81,7 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 export const dateTimeToColorBetween = (startTime: Date, startColor: number[], endColor: number[]): string => {
   const sunrise = 5 // hours
   const sunset = 5 + 12
-  const fade = 2  // wide transition since this accounts for varying daylight
+  const fade = 2 // wide transition since this accounts for varying daylight
 
   const hours = startTime.getHours() + startTime.getMinutes() / 60
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -78,17 +78,46 @@ export const formatDate = (input: dayjs.ConfigType): string => {
   return date.format('MMMM Do' + yearStr)
 }
 
-export const dateTimeToColorBetween = (date: Date, startColor: string, endColor: string): string => {
+function l(t: number) {
+  const startTime = 6
+  const endTime = 5 + 12
+  const fadeHours = 2
+  if ((startTime < t) && (t < (startTime + fadeHours))) return (t - startTime) / fadeHours
+  if ((endTime < t) && (t < (endTime + fadeHours))) return (t - endTime) / fadeHours
+  if ((startTime < t) && (t < (endTime + fadeHours))) return 1
+  // if ((startTime + 2) < t && t < endTime) return 1
+
+  // if (t < 6) return 0
+  // if (t > (7.5 + 12)) return 0
+  // if (t < 8) return Math.min((t - 5)/2, 1)
+  // if (t > 18) return 1-Math.min((t - 17), 1)
+  return 0
+  // return 1 / (1 + Math.exp(-2 * (t - 6))) - 1 / (1 + Math.exp(-2 * (t - 19)));
+}
+
+export const dateTimeToColorBetween = (startTime: Date, endTime: Date, startColor: string, endColor: string): { start: string; end: string } => {
   const toRGB = (hex: string): number[] => hex.match(/\w\w/g)!.map((x) => parseInt(x, 16))
   const toHex = (rgb: number[]): string => rgb.map((x) => Math.round(x).toString(16).padStart(2, '0')).join('')
 
-  const minutes = date.getHours() * 60 + date.getMinutes()
-  const t = minutes / 720
-  const blendFactor = t <= 1 ? t : 2 - t
+  const hoursStart = startTime.getHours() + startTime.getMinutes() / 60
+  const hoursEnd = endTime.getHours() + endTime.getMinutes() / 60
+  // const minutes = startTime.getHours() * 60 + startTime.getMinutes()
+  // const t = minutes / 720
+  // const blendFactor = t <= 1 ? t : 2 - t
+  // const blendFactor = Math.max(Math.min(Math.sin(Math.PI / 14 * (hours - 5)), 1), 0)
+  const blendFactorStart = l(hoursStart)
+  const blendFactorEnd = l(hoursEnd)
+  console.log('hoursStart', hoursStart, 't', 'blendFactorStart', blendFactorStart)
+
 
   const rgb1 = toRGB(startColor)
   const rgb2 = toRGB(endColor)
-  const blended = rgb1.map((c, i) => c + (rgb2[i] - c) * blendFactor)
+  // const blended = rgb1.map((c, i) => c + (rgb2[i] - c) * blendFactor)
+  const blendedStart = rgb1.map((c, i) => c + (rgb2[i] - c) * blendFactorStart)
+  const blendedEnd = rgb1.map((c, i) => c + (rgb2[i] - c) * blendFactorEnd)
 
-  return `#${toHex(blended)}`
+  const start = `#${toHex(blendedStart)}`
+  const end = `#${toHex(blendedEnd)}`
+  return {start, end}
+  // return `#${toHex(blended)}`
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -79,7 +79,7 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 }
 
 export const dateTimeToColorBetween = (startTime: Date, startColor: number[], endColor: number[]): string => {
-  const fadeStart = 5  // hours
+  const fadeStart = 5 // hours
   const fadeEnd = 6 + 12
   const fade = 2
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -81,7 +81,7 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 export const dateTimeToColorBetween = (startTime: Date, startColor: number[], endColor: number[]): string => {
   const sunrise = 5 // hours
   const sunset = 5 + 12
-  const fade = 2
+  const fade = 2  // wide transition since this accounts for varying daylight
 
   const hours = startTime.getHours() + startTime.getMinutes() / 60
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -102,23 +102,26 @@ export const dateTimeToColorBetween = (startTime: Date, endTime: Date, startColo
 
   const hoursStart = startTime.getHours() + startTime.getMinutes() / 60
   const hoursEnd = endTime.getHours() + endTime.getMinutes() / 60
+  const hoursAvg = (hoursStart + hoursEnd) / 2
   // const minutes = startTime.getHours() * 60 + startTime.getMinutes()
   // const t = minutes / 720
   // const blendFactor = t <= 1 ? t : 2 - t
   // const blendFactor = Math.max(Math.min(Math.sin(Math.PI / 14 * (hours - 5)), 1), 0)
   const blendFactorStart = l(hoursStart)
   const blendFactorEnd = l(hoursEnd)
-  console.log('hoursStart', hoursStart, 't', 'blendFactorStart', blendFactorStart)
-
+  const blendFactorAvg = l(hoursAvg)
+  console.log('hoursStart', hoursStart, 'hoursEnd', hoursEnd, 'hoursAvg', hoursAvg, blendFactorAvg)
 
   const rgb1 = toRGB(startColor)
   const rgb2 = toRGB(endColor)
   // const blended = rgb1.map((c, i) => c + (rgb2[i] - c) * blendFactor)
   const blendedStart = rgb1.map((c, i) => c + (rgb2[i] - c) * blendFactorStart)
   const blendedEnd = rgb1.map((c, i) => c + (rgb2[i] - c) * blendFactorEnd)
+  const blendedAvg = rgb1.map((c, i) => c + (rgb2[i] - c) * blendFactorAvg)
 
-  const start = `#${toHex(blendedStart)}`
-  const end = `#${toHex(blendedEnd)}`
-  return {start, end}
+  // const start = `#${toHex(blendedStart)}`
+  // const end = `#${toHex(blendedEnd)}`
+  const avg = `#${toHex(blendedAvg)}`
+  return {start: avg, end: avg}
   // return `#${toHex(blended)}`
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -80,31 +80,16 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 
 function l(t: number) {
   // these are averages throughout the year in San Diego
-  // TODO: calculate correct times based on route date
+  // TODO: calculate correct times based on route date (for winter)
   const sunrise = 6.5
   const sunset = 6.5 + 12
   const twilight = 0.5  // civil twilight is 25 minutes on average
   // looked outside and it got dark at 7:40 (sunset was 7:11)
-  // t = t + 1
 
   if ((sunrise < t) && (t < (sunrise + twilight))) return (t - sunrise) / twilight
   if ((sunset < t) && (t < (sunset + twilight))) return 1 - (t - sunset) / twilight
   if ((sunrise < t) && (t < (sunset + twilight))) return 1
-
-  // const startTime = 6.5
-  // const endTime = 6 + 12
-  // const fadeHours = 0.5
-  // if ((startTime < t) && (t < (startTime + fadeHours))) return (t - startTime) / fadeHours
-  // if ((endTime < t) && (t < (endTime + fadeHours))) return 1 - (t - endTime) / fadeHours
-  // if ((startTime < t) && (t < (endTime + fadeHours))) return 1
-  // // if ((startTime + 2) < t && t < endTime) return 1
-
-  // if (t < 6) return 0
-  // if (t > (7.5 + 12)) return 0
-  // if (t < 8) return Math.min((t - 5)/2, 1)
-  // if (t > 18) return 1-Math.min((t - 17), 1)
   return 0
-  // return 1 / (1 + Math.exp(-2 * (t - 6))) - 1 / (1 + Math.exp(-2 * (t - 19)));
 }
 
 export const dateTimeToColorBetween = (startTime: Date, endTime: Date, startColor: string, endColor: string): { start: string; end: string } => {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -89,7 +89,7 @@ const rgbToHex = (rgb: [number, number, number]): string => '#' + rgb.map((v) =>
 
 const blend = (a: number, b: number, mix: number): number => Math.round(a * mix + b * (1 - mix))
 
-export const dateToGradient = (date: Date, colorA: string, colorB: string, centerHour = 9): string => {
+export const dateToGradient = (date: Date, colorA: string, colorB: string, centerHour = 9, power = 6): string => {
   const [r1, g1, b1] = hexToRgb(colorA)
   const [r2, g2, b2] = hexToRgb(colorB)
 
@@ -100,7 +100,9 @@ export const dateToGradient = (date: Date, colorA: string, colorB: string, cente
 
   // cosine smooths transition between colorA and colorB
   const theta = t * 2 * Math.PI
-  const mix = (1 + Math.cos(theta)) / 2
+  const baseMix = (1 + Math.cos(theta)) / 2
+  // raise to power to make transition more pronounced
+  const mix = baseMix ** power / (baseMix ** power + (1 - baseMix) ** power)
 
   return rgbToHex([blend(r1, r2, mix), blend(g1, g2, mix), blend(b1, b2, mix)])
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -79,11 +79,11 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 }
 
 function l(t: number) {
-  const startTime = 6
-  const endTime = 5 + 12
-  const fadeHours = 2
+  const startTime = 6.5
+  const endTime = 6 + 12
+  const fadeHours = 1
   if ((startTime < t) && (t < (startTime + fadeHours))) return (t - startTime) / fadeHours
-  if ((endTime < t) && (t < (endTime + fadeHours))) return (t - endTime) / fadeHours
+  if ((endTime < t) && (t < (endTime + fadeHours))) return 1 - (t - endTime) / fadeHours
   if ((startTime < t) && (t < (endTime + fadeHours))) return 1
   // if ((startTime + 2) < t && t < endTime) return 1
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -89,7 +89,7 @@ const rgbToHex = (rgb: [number, number, number]): string => '#' + rgb.map((v) =>
 
 const blend = (a: number, b: number, mix: number): number => Math.round(a * mix + b * (1 - mix))
 
-export const dateToGradient = (date: Date, colorA: string, colorB: string, centerHour = 12, power = 6): string => {
+export const dateToGradient = (date: Date, colorA: string, colorB: string, centerHour = 10, power = 8): string => {
   const [r1, g1, b1] = hexToRgb(colorA)
   const [r2, g2, b2] = hexToRgb(colorB)
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -79,14 +79,25 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 }
 
 function l(t: number) {
-  t = t + 1
-  const startTime = 6.5
-  const endTime = 6 + 12
-  const fadeHours = 0.5
-  if ((startTime < t) && (t < (startTime + fadeHours))) return (t - startTime) / fadeHours
-  if ((endTime < t) && (t < (endTime + fadeHours))) return 1 - (t - endTime) / fadeHours
-  if ((startTime < t) && (t < (endTime + fadeHours))) return 1
-  // if ((startTime + 2) < t && t < endTime) return 1
+  // these are averages throughout the year in San Diego
+  // TODO: calculate correct times based on route date
+  const sunrise = 6.5
+  const sunset = 6.5 + 12
+  const twilight = 0.5  // civil twilight is 25 minutes on average
+  // looked outside and it got dark at 7:40 (sunset was 7:11)
+  // t = t + 1
+
+  if ((sunrise < t) && (t < (sunrise + twilight))) return (t - sunrise) / twilight
+  if ((sunset < t) && (t < (sunset + twilight))) return 1 - (t - sunset) / twilight
+  if ((sunrise < t) && (t < (sunset + twilight))) return 1
+
+  // const startTime = 6.5
+  // const endTime = 6 + 12
+  // const fadeHours = 0.5
+  // if ((startTime < t) && (t < (startTime + fadeHours))) return (t - startTime) / fadeHours
+  // if ((endTime < t) && (t < (endTime + fadeHours))) return 1 - (t - endTime) / fadeHours
+  // if ((startTime < t) && (t < (endTime + fadeHours))) return 1
+  // // if ((startTime + 2) < t && t < endTime) return 1
 
   // if (t < 6) return 0
   // if (t > (7.5 + 12)) return 0
@@ -102,7 +113,7 @@ export const dateTimeToColorBetween = (startTime: Date, endTime: Date, startColo
 
   const hoursStart = startTime.getHours() + startTime.getMinutes() / 60
   const hoursEnd = endTime.getHours() + endTime.getMinutes() / 60
-  const hoursAvg = (hoursStart + hoursEnd) / 2
+  const hoursAvg = hoursEnd  // (hoursStart + hoursEnd) / 2
   // const minutes = startTime.getHours() * 60 + startTime.getMinutes()
   // const t = minutes / 720
   // const blendFactor = t <= 1 ? t : 2 - t

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -79,17 +79,17 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 }
 
 export const dateTimeToColorBetween = (startTime: Date, startColor: number[], endColor: number[]): string => {
-  const fadeStart = 5 // hours
-  const fadeEnd = 6 + 12
+  const sunrise = 5 // hours
+  const sunset = 6 + 12
   const fade = 2
 
   const hours = startTime.getHours() + startTime.getMinutes() / 60
 
   let blendFactor = 0
-  if (fadeStart < hours && hours < fadeEnd) {
-    blendFactor = Math.min((hours - fadeStart) / fade, 1)
-  } else if (fadeEnd <= hours) {
-    blendFactor = Math.max(1 - (hours - fadeEnd) / fade, 0)
+  if (sunrise < hours && hours < sunset) {
+    blendFactor = Math.min((hours - sunrise) / fade, 1)
+  } else if (sunset <= hours) {
+    blendFactor = Math.max(1 - (hours - sunset) / fade, 0)
   }
 
   const blended = startColor.map((c, i) => c + (endColor[i] - c) * blendFactor)


### PR DESCRIPTION
my take on the route color, but attempting to be simpler, no deps (thx gpt)

pending:
- [x] test cases

<img width="292" alt="image" src="https://github.com/user-attachments/assets/d66765a5-adad-458b-9544-91576573e622" />
