### PR TITLE
Daylight indicator: just make it good for current season and location

### DIFF
--- a/src/utils/format.spec.ts
+++ b/src/utils/format.spec.ts
@@ -56,8 +56,8 @@ describe('formatDate', () => {
 describe('dateTimeToColorBetween', () => {
   it('should generate a color between two colors', () => {
     expect(dateTimeToColorBetween(new Date('2025-02-01T00:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(30, 57, 138)')
-    expect(dateTimeToColorBetween(new Date('2025-02-01T06:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(124, 109, 83)')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T06:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(93, 92, 101)')
     expect(dateTimeToColorBetween(new Date('2025-02-01T12:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(218, 161, 28)')
-    expect(dateTimeToColorBetween(new Date('2025-02-01T18:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(124, 109, 83)')
+    expect(dateTimeToColorBetween(new Date('2025-02-01T18:00:00.000Z'), [30, 57, 138], [218, 161, 28])).toBe('rgb(218, 161, 28)')
   })
 })

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -93,6 +93,6 @@ export const dateTimeToColorBetween = (startTime: Date, startColor: number[], en
     blendFactor = Math.max(1 - (hours - sunset) / fade, 0)
   }
 
-  const blended = startColor.map((c, i) => c + (endColor[i] - c) * blendFactor)
+  const blended = startColor.map((c, i) => Math.round(c + (endColor[i] - c) * blendFactor))
   return `rgb(${blended.join(', ')})`
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -79,9 +79,10 @@ export const formatDate = (input: dayjs.ConfigType): string => {
 }
 
 export const dateTimeToColorBetween = (startTime: Date, startColor: number[], endColor: number[]): string => {
-  const sunrise = 5 // hours
-  const sunset = 5 + 12
-  const fade = 2 // wide transition since this accounts for different seasons
+  // FIXME: adjust based on season
+  const sunrise = 5.5 // hours
+  const sunset = 6.5 + 12
+  const fade = 1.5 // wide transition since this accounts for different seasons
 
   const hours = startTime.getHours() + startTime.getMinutes() / 60
 


### PR DESCRIPTION
I selected averages for all seasons and locations, but then it's not good anywhere. For now it's calibrated to accurately depict thumbnails in San Diego in the summer