### PR TITLE
fix: remove deprecated apple meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
     <meta property="og:image" content="/apple-touch-icon-180x180.png" />
     <title>connect</title>
 
+    <meta name="mobile-web-app-capable" content="yes">
+
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300..800&family=JetBrains+Mono:wght@400;500&display=swap" />
 
     <script defer data-domain="connect.comma.ai" src="https://plausible.io/js/script.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
     <meta property="og:image" content="/apple-touch-icon-180x180.png" />
     <title>connect</title>
 
-    <meta name="apple-mobile-web-app-capable" content="yes">
-
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300..800&family=JetBrains+Mono:wght@400;500&display=swap" />
 
     <script defer data-domain="connect.comma.ai" src="https://plausible.io/js/script.js"></script>


### PR DESCRIPTION
https://web.dev/learn/pwa/web-app-manifest#designing_your_pwa_experience

don't think this is needed anymore

on master it complains

<img width="967" alt="image" src="https://github.com/user-attachments/assets/f2cfeaa3-8178-41da-b6bf-a26b97ec5371" />
