### PR TITLE
fix: Comma logo shifts on first load

### DIFF
--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -99,7 +99,7 @@ const DashboardLayout: Component<{
             class="font-bold"
             leading={
               <Show when={!modal()} fallback={<DrawerToggleButton />}>
-                <img alt="" src="/images/comma-white.png" class="h-8" />
+                <img alt="Comma logo" src="/images/comma-white.svg" height="32" width="32" />
               </Show>
             }
           >

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -83,6 +83,7 @@ const DashboardLayout: Component<{
   paneTwo: JSXElement
   paneTwoContent: boolean
 }> = (props) => {
+  const { modal } = useDrawerContext()
   return (
     <div class="relative size-full overflow-hidden">
       <div
@@ -93,7 +94,19 @@ const DashboardLayout: Component<{
           props.paneTwoContent ? '-translate-x-full md:translate-x-0' : 'translate-x-0',
         )}
       >
-        <div class="min-w-full overflow-y-scroll">{props.paneOne}</div>
+        <div class="min-w-full overflow-y-scroll">
+          <TopAppBar
+            class="font-bold"
+            leading={
+              <Show when={!modal()} fallback={<DrawerToggleButton />}>
+                <img alt="" src="/images/comma-white.png" class="h-8" />
+              </Show>
+            }
+          >
+            connect
+          </TopAppBar>
+          {props.paneOne}
+        </div>
         <div class="min-w-full overflow-y-scroll">{props.paneTwo}</div>
       </div>
     </div>
@@ -128,7 +141,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
 
   return (
     <Drawer drawer={<DashboardDrawer devices={devices()} />}>
-      <Switch fallback={<TopAppBar leading={<DrawerToggleButton />}>No device</TopAppBar>}>
+      <Switch>
         <Match when={urlState().dongleId === 'pair' || !!location.query.pair}>
           <PairActivity />
         </Match>

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -6,10 +6,8 @@ import { getDevice, SHARED_DEVICE } from '~/api/devices'
 import { ATHENA_URL } from '~/api/config'
 import { getAccessToken } from '~/api/auth/client'
 
-import { DrawerToggleButton, useDrawerContext } from '~/components/material/Drawer'
 import Icon from '~/components/material/Icon'
 import IconButton from '~/components/material/IconButton'
-import TopAppBar from '~/components/material/TopAppBar'
 import DeviceLocation from '~/components/DeviceLocation'
 import DeviceStatistics from '~/components/DeviceStatistics'
 import { deviceIsOnline, getDeviceName } from '~/utils/device'
@@ -107,20 +105,8 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
     setSnapshot({ ...snapshot(), error: null })
   }
 
-  const { modal } = useDrawerContext()
-
   return (
     <>
-      <TopAppBar
-        class="font-bold"
-        leading={
-          <Show when={!modal()} fallback={<DrawerToggleButton />}>
-            <img alt="" src="/images/comma-white.png" class="h-8" />
-          </Show>
-        }
-      >
-        connect
-      </TopAppBar>
       <div class="flex flex-col gap-4 px-4 pb-4">
         <div class="h-min overflow-hidden rounded-lg bg-surface-container-low">
           <Suspense fallback={<div class="h-[240px] skeleton-loader size-full" />}>


### PR DESCRIPTION
fixes a reflow on first load. its better to define w/h via attribute instead of css so the browser knows how to place it before the image loads

must merge https://github.com/commaai/connect/pull/515 first, this is a no-line change