### PR TITLE
feat(statistics): use log duration in route stats

### DIFF
--- a/src/components/RouteStatisticsBar.tsx
+++ b/src/components/RouteStatisticsBar.tsx
@@ -1,4 +1,4 @@
-import type { VoidComponent } from 'solid-js'
+import type { Resource, VoidComponent } from 'solid-js'
 
 import type { RouteStatistics } from '~/api/derived'
 import type { Route } from '~/api/types'
@@ -11,9 +11,7 @@ const formatEngagement = (statistics: RouteStatistics | undefined): string | und
   return `${(100 * (engagedDurationMs / routeDurationMs)).toFixed(0)}%`
 }
 
-const RouteStatisticsBar: VoidComponent<{ class?: string; route: Route | undefined; statistics: RouteStatistics | undefined }> = (
-  props,
-) => {
+const RouteStatisticsBar: VoidComponent<{ class?: string; route: Route | undefined; statistics: Resource<RouteStatistics> }> = (props) => {
   return (
     <StatisticBar
       class={props.class}
@@ -22,11 +20,13 @@ const RouteStatisticsBar: VoidComponent<{ class?: string; route: Route | undefin
         {
           label: 'Duration',
           value: () => {
-            if (props.statistics) return formatDuration(props.statistics.routeDurationMs / (60 * 1000))
+            if (props.statistics.state === 'ready' || props.statistics.state === 'refreshing') {
+              return formatDuration(props.statistics.latest.routeDurationMs / (60 * 1000))
+            }
             return formatRouteDuration(props.route)
           },
         },
-        { label: 'Engaged', value: () => formatEngagement(props.statistics) },
+        { label: 'Engaged', value: () => formatEngagement(props.statistics()) },
       ]}
     />
   )

--- a/src/components/RouteStatisticsBar.tsx
+++ b/src/components/RouteStatisticsBar.tsx
@@ -2,7 +2,7 @@ import type { VoidComponent } from 'solid-js'
 
 import type { RouteStatistics } from '~/api/derived'
 import type { Route } from '~/api/types'
-import { formatDistance, formatRouteDuration } from '~/utils/format'
+import { formatDistance, formatDuration, formatRouteDuration } from '~/utils/format'
 import StatisticBar from './StatisticBar'
 
 const formatEngagement = (statistics: RouteStatistics | undefined): string | undefined => {
@@ -19,7 +19,13 @@ const RouteStatisticsBar: VoidComponent<{ class?: string; route: Route | undefin
       class={props.class}
       statistics={[
         { label: 'Distance', value: () => formatDistance(props.route?.length) },
-        { label: 'Duration', value: () => (props.route ? formatRouteDuration(props.route) : undefined) },
+        {
+          label: 'Duration',
+          value: () => {
+            if (props.statistics) return formatDuration(props.statistics.routeDurationMs / (60 * 1000))
+            return formatRouteDuration(props.route)
+          },
+        },
         { label: 'Engaged', value: () => formatEngagement(props.statistics) },
       ]}
     />

--- a/src/components/RouteStatisticsBar.tsx
+++ b/src/components/RouteStatisticsBar.tsx
@@ -21,7 +21,7 @@ const RouteStatisticsBar: VoidComponent<{ class?: string; route: Route | undefin
           label: 'Duration',
           value: () => {
             if (props.statistics.state === 'ready' || props.statistics.state === 'refreshing') {
-              return formatDuration(props.statistics.latest.routeDurationMs / (60 * 1000))
+              return formatDuration(props.statistics().routeDurationMs / (60 * 1000))
             }
             return formatRouteDuration(props.route)
           },

--- a/src/components/RouteStatisticsBar.tsx
+++ b/src/components/RouteStatisticsBar.tsx
@@ -19,12 +19,10 @@ const RouteStatisticsBar: VoidComponent<{ class?: string; route: Route | undefin
         { label: 'Distance', value: () => formatDistance(props.route?.length) },
         {
           label: 'Duration',
-          value: () => {
-            if (props.statistics.state === 'ready' || props.statistics.state === 'refreshing') {
-              return formatDuration(props.statistics().routeDurationMs / (60 * 1000))
-            }
-            return formatRouteDuration(props.route)
-          },
+          value: () =>
+            props.statistics.state === 'ready' || props.statistics.state === 'refreshing'
+              ? formatDuration(props.statistics().routeDurationMs / (60 * 1000))
+              : formatRouteDuration(props.route),
         },
         { label: 'Engaged', value: () => formatEngagement(props.statistics()) },
       ]}

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -80,7 +80,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
         <div class="flex flex-col gap-2">
           <span class="text-label-md uppercase">Route Info</span>
           <div class="flex flex-col rounded-md overflow-hidden bg-surface-container">
-            <RouteStatisticsBar class="p-5" route={route()} statistics={statistics()} />
+            <RouteStatisticsBar class="p-5" route={route()} statistics={statistics} />
 
             <RouteActions routeName={routeName()} route={route()} />
           </div>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -22,7 +22,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs.utc(props.route.start_time).local()
   const endTime = () => dayjs.utc(props.route.end_time).local()
   const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), [30, 57, 138], [218, 161, 28])
-  const [statistics] = createResource(() => getRouteStatistics(props.route))
+  const [statistics] = createResource(() => props.route, getRouteStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
     const endPos = [props.route.end_lng || 0, props.route.end_lat || 0]

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -22,7 +22,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs.utc(props.route.start_time).local()
   const endTime = () => dayjs.utc(props.route.end_time).local()
   const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), [30, 57, 138], [218, 161, 28])
-  const [statistics] = createResource(() => props.route, getRouteStatistics)
+  const [statistics] = createResource(() => getRouteStatistics(props.route))
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
     const endPos = [props.route.end_lng || 0, props.route.end_lat || 0]
@@ -55,7 +55,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       />
 
       <CardContent>
-        <RouteStatisticsBar route={props.route} statistics={statistics()} />
+        <RouteStatisticsBar route={props.route} statistics={statistics} />
       </CardContent>
       <div class="h-2.5 w-full" style={{ background: color() }} />
     </Card>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -57,10 +57,10 @@ export const getRouteDuration = (route: Route | undefined): Duration | undefined
   return dayjs.duration(endTime.diff(startTime))
 }
 
-export const formatRouteDuration = (route: Route | undefined): string => {
-  if (!route) return ''
+export const formatRouteDuration = (route: Route | undefined): string | undefined => {
+  if (!route) return undefined
   const duration = getRouteDuration(route)
-  return duration ? _formatDuration(duration) : ''
+  return duration ? _formatDuration(duration) : undefined
 }
 
 const parseTimestamp = (input: dayjs.ConfigType): dayjs.Dayjs => {


### PR DESCRIPTION
Use route duration from logs for statistics, if available

after #528