### PR TITLE
fix(types): update route types

### DIFF
--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -54,43 +54,42 @@ export interface DrivingStatistics {
 }
 
 export interface Route extends ApiResponseBase {
-  can?: boolean
+  can: boolean
   create_time: number
   devicetype: number
   dongle_id: string
-  end_lat?: number
-  end_lng?: number
-  end_time?: string
+  end_lat: number // default to 0
+  end_lng: number // default to 0
+  end_time: string | null
   fullname: string
-  git_branch?: string
-  git_commit?: string
-  git_dirty?: boolean
-  git_remote?: string
-  hpgps?: boolean
-  init_logmonotime?: number
+  git_branch: string | null
+  git_commit: string | null
+  git_dirty: boolean | null
+  git_remote: string | null
+  hpgps: boolean
+  init_logmonotime: number | null
   is_public: boolean
-  is_preserved: boolean
-  length?: number
+  length: number // default to 0
   maxcamera: number
   maxdcamera: number
   maxecamera: number
   maxlog: number
   maxqcamera: number
   maxqlog: number
-  passive?: boolean
-  platform?: string
+  passive: boolean | null
+  platform: string | null
   proccamera: number
   proclog: number
   procqcamera: number
   procqlog: number
-  radar?: boolean
-  start_lat?: number
-  start_lng?: number
-  start_time?: string
+  radar: boolean
+  start_lat: number // default to 0
+  start_lng: number // default to 0
+  start_time: string | null
   url: string
   user_id: string | null
-  version?: string
-  vin?: string
+  version: string | null
+  vin: string | null
 }
 
 export interface RouteInfo {

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -86,7 +86,7 @@ export interface Route extends ApiResponseBase {
   radar?: boolean
   start_lat?: number
   start_lng?: number
-  start_time: string
+  start_time?: string
   url: string
   user_id: string | null
   version?: string

--- a/src/components/RouteActions.tsx
+++ b/src/components/RouteActions.tsx
@@ -49,9 +49,7 @@ const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
     const preservedRoutes = preservedRoutesResource()
     if (!props.route) return
     setIsPublic(props.route.is_public)
-    if (props.route.is_preserved) {
-      setIsPreserved(true)
-    } else if (preservedRoutes) {
+    if (preservedRoutes) {
       const { fullname } = props.route
       setIsPreserved(preservedRoutes.some((r) => r.fullname === fullname))
     } else {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -51,7 +51,7 @@ export const formatVideoTime = (seconds: number): string => {
 }
 
 export const getRouteDuration = (route: Route | undefined): Duration | undefined => {
-  if (!route || !route.end_time) return undefined
+  if (!route || !route.start_time || !route.end_time) return undefined
   const startTime = dayjs(route.start_time)
   const endTime = dayjs(route.end_time)
   return dayjs.duration(endTime.diff(startTime))


### PR DESCRIPTION
- API returns `null` for many
- `route.start_time` can be null too
- there is no `route.is_preserved` (this was included in `routes_segments` endpoint)