### PR TITLE
fix: only check isSignedIn for login status

### DIFF
--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -105,7 +105,6 @@ const Dashboard: Component<RouteSectionProps> = () => {
   })
 
   const [devices, { refetch }] = createResource(getDevices, { initialValue: [] })
-  const [profile] = createResource(getProfile)
 
   const getDefaultDongleId = () => {
     // Do not redirect if dongle ID already selected
@@ -119,7 +118,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
   return (
     <Drawer drawer={<DashboardDrawer devices={devices()} />}>
       <Switch fallback={<TopAppBar leading={<DrawerToggleButton />}>No device</TopAppBar>}>
-        <Match when={!isSignedIn() || (!profile.loading && !profile.latest)}>
+        <Match when={!isSignedIn()}>
           <Navigate href="/login" />
         </Match>
         <Match when={urlState().dongleId === 'pair' || !!location.query.pair}>


### PR DESCRIPTION
resolves: https://github.com/commaai/connect/issues/533

we only need to check if the access token is set to know the user is logged in. removes an unnecessary profile call, too!