### PR TITLE
refactor: add reactivity helper isResolved

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -2,4 +2,4 @@ import type { Profile } from '~/api/types'
 
 import { fetcher } from '.'
 
-export const getProfile = async () => fetcher<Profile>('/v1/me/').catch(() => undefined)
+export const getProfile = async () => fetcher<Profile>('/v1/me/')

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createResource, lazy, Match, Show, Suspense, Switch } from 'solid-js'
+import { createMemo, createResource, ErrorBoundary, lazy, Match, Show, Suspense, Switch } from 'solid-js'
 import type { Component, JSXElement, VoidComponent } from 'solid-js'
 import { Navigate, type RouteSectionProps, useLocation } from '@solidjs/router'
 import clsx from 'clsx'
@@ -55,8 +55,10 @@ const DashboardDrawer: VoidComponent<{ devices: Device[] }> = (props) => {
                 <Icon name="person" filled />
               </div>
               <div class="min-w-0 mx-3">
-                <div class="truncate text-sm text-on-surface">{profile()?.email}</div>
-                <div class="truncate text-xs text-on-surface-variant">{profile()?.user_id}</div>
+                <ErrorBoundary fallback="Error loading profile">
+                  <div class="truncate text-sm text-on-surface">{profile()?.email}</div>
+                  <div class="truncate text-xs text-on-surface-variant">{profile()?.user_id}</div>
+                </ErrorBoundary>
               </div>
               <div class="grow" />
               <IconButton name="logout" href="/logout" />

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -51,8 +51,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
   const [device] = createResource(() => props.dongleId, getDevice)
   const [profile] = createResource(getProfile)
   createEffect(() => {
-    if (!resolved(device) || !resolved(profile)) return
-    if (!device().is_owner && !profile().superuser) return
+    if (!resolved(device) || !resolved(profile) || (!device().is_owner && !profile().superuser)) return
     void setRouteViewed(device().dongle_id, props.dateStr)
   })
 

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -7,6 +7,7 @@ import { getDevice } from '~/api/devices'
 import { getProfile } from '~/api/profile'
 import { getRoute } from '~/api/route'
 import { dayjs } from '~/utils/format'
+import { resolved } from '~/utils/reactivity'
 
 import IconButton from '~/components/material/IconButton'
 import TopAppBar from '~/components/material/TopAppBar'
@@ -49,13 +50,11 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
 
   const [device] = createResource(() => props.dongleId, getDevice)
   const [profile] = createResource(getProfile)
-  createResource(
-    () => [device(), profile(), props.dateStr] as const,
-    async ([device, profile, dateStr]) => {
-      if (!device || !profile || (!device.is_owner && !profile.superuser)) return
-      await setRouteViewed(device.dongle_id, dateStr)
-    },
-  )
+  createEffect(() => {
+    if (!resolved(device) || !resolved(profile)) return
+    if (!device().is_owner && !profile().superuser) return
+    void setRouteViewed(device().dongle_id, props.dateStr)
+  })
 
   return (
     <>

--- a/src/utils/reactivity.ts
+++ b/src/utils/reactivity.ts
@@ -1,0 +1,21 @@
+import type { Resource } from 'solid-js'
+
+// from https://github.com/solidjs/solid/blob/main/packages/solid/src/reactive/signal.ts#L483
+interface Ready<T> {
+  state: 'ready'
+  loading: false
+  error: undefined
+  latest: T
+  (): T
+}
+interface Refreshing<T> {
+  state: 'refreshing'
+  loading: true
+  error: undefined
+  latest: T
+  (): T
+}
+
+export function resolved<T>(data: Resource<T>): data is Ready<T> | Refreshing<T> {
+  return data.state === 'ready' || data.state === 'refreshing'
+}

--- a/src/utils/reactivity.ts
+++ b/src/utils/reactivity.ts
@@ -1,6 +1,7 @@
 import type { Resource } from 'solid-js'
 
-// from https://github.com/solidjs/solid/blob/main/packages/solid/src/reactive/signal.ts#L483
+// these types aren't exported
+// from https://github.com/solidjs/solid/blob/v1.9.5/packages/solid/src/reactive/signal.ts#L483
 interface Ready<T> {
   state: 'ready'
   loading: false


### PR DESCRIPTION
Narrows the type of a resource so that you can "safely" read from it without triggering Suspense

Also added an error boundary for the profile
![image](https://github.com/user-attachments/assets/23ff231f-1a8e-45ac-b216-c8f11354c8f6)
