### PR TITLE
fix: set max-width on Icon

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -181,25 +181,23 @@
   .material-symbols-outlined {
     transition: font-variation-settings 0.2s;
     font-variation-settings: "FILL" var(--font-filled, 0), "OPSZ" var(--font-opsz, 24);
+    font-size: calc(var(--font-opsz, 24) * 1px);
+    max-width: calc(var(--font-opsz, 24) * 1px);
 
     &.size-20 {
       --font-opsz: 20;
-      font-size: 20px;
     }
 
     &.size-24 {
       --font-opsz: 24;
-      font-size: 24px;
     }
 
     &.size-40 {
       --font-opsz: 40;
-      font-size: 40px;
     }
 
     &.size-48 {
       --font-opsz: 48;
-      font-size: 48px;
     }
 
     &.icon-outline {


### PR DESCRIPTION
This ensures elements don't resize while the icon font is loading