### PR TITLE
feat(PairActivity): add 'grant' permission screen

### DIFF
--- a/src/pages/dashboard/activities/PairActivity.tsx
+++ b/src/pages/dashboard/activities/PairActivity.tsx
@@ -115,8 +115,10 @@ const PairActivity: VoidComponent<{ onPaired: () => void }> = (props) => {
               .then(() => {
                 to.scanning()
               })
-              .catch((err) => {
-                console.error('Failed to request permission', err)
+              .catch((reason) => {
+                const error = toError(reason)
+                console.error('Failed to request permission', error)
+                to.error({ error })
               })
           }
         })

--- a/src/pages/dashboard/activities/PairActivity.tsx
+++ b/src/pages/dashboard/activities/PairActivity.tsx
@@ -1,7 +1,8 @@
-import { onCleanup, onMount, type JSX, type VoidComponent } from 'solid-js'
+import { createEffect, createSignal, on, onCleanup, onMount, Show, type JSX, type VoidComponent } from 'solid-js'
 import { useLocation, useNavigate } from '@solidjs/router'
 import { createMachine } from '@solid-primitives/state-machine'
 import QrScanner from 'qr-scanner'
+import clsx from 'clsx'
 
 import { pairDevice } from '~/api/devices'
 import Button from '~/components/material/Button'
@@ -17,14 +18,74 @@ const toError = (error: unknown): Error => {
   return new Error('An unknown error occurred', { cause: error })
 }
 
+/**
+ * @see https://github.com/solidjs-community/solid-primitives/blob/main/packages/permission/src/index.ts#L10
+ */
+const createPermission = (name: PermissionName) => {
+  const [permission, setPermission] = createSignal<PermissionState | 'unknown'>('unknown')
+  const [status, setStatus] = createSignal<PermissionStatus>()
+
+  navigator.permissions
+    .query({ name })
+    .then(setStatus)
+    .catch((error) => {
+      if (error.name !== 'TypeError') return
+      // firefox will not allow us to read media permissions,
+      // so we need to wrap getUserMedia in order to get them:
+      // TODO: only set to prompt if devices are available
+      setPermission('prompt')
+      const constraint = 'video'
+      const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices)
+      navigator.mediaDevices.getUserMedia = (constraints) =>
+        constraints?.[constraint]
+          ? getUserMedia(constraints)
+              .then((stream) => {
+                setPermission('granted')
+                return stream
+              })
+              .catch((error) => {
+                if (/not allowed/.test(error.message)) {
+                  setPermission('denied')
+                }
+                return Promise.reject(error)
+              })
+          : getUserMedia(constraints)
+    })
+  createEffect(
+    on(status, (status) => {
+      if (!status) return
+      setPermission(status.state)
+      const listener = () => setPermission(status.state)
+      status.addEventListener('change', listener)
+      onCleanup(() => status.removeEventListener('change', listener))
+    }),
+  )
+
+  return permission
+}
+
+/**
+ * Create a media request that will be stopped immediately in order to request permissions from the user
+ * @see https://github.com/solidjs-community/solid-primitives/blob/main/packages/stream/src/index.ts#L291
+ */
+const createMediaPermissionRequest = async (source: MediaStreamConstraints) => {
+  const stream = await navigator.mediaDevices.getUserMedia(source)
+  stream.getTracks().forEach((track) => track.stop())
+}
+
 const PairActivity: VoidComponent<{ onPaired: () => void }> = (props) => {
   const { pair } = useLocation().query
   const pairToken: string | undefined = Array.isArray(pair) ? pair[0] : pair
 
+  const permission = createPermission('camera')
   const state = createMachine<{
+    grant: {
+      value: JSX.Element
+      to: 'scanning' | 'error'
+    }
     scanning: {
       value: JSX.Element
-      to: 'pairing' | 'error'
+      to: 'grant' | 'pairing' | 'error'
     }
     pairing: {
       input: { pairToken: string }
@@ -34,7 +95,7 @@ const PairActivity: VoidComponent<{ onPaired: () => void }> = (props) => {
     error: {
       input: { error: Error }
       value: JSX.Element
-      to: 'scanning'
+      to: 'grant'
     }
   }>({
     initial: pairToken
@@ -42,11 +103,41 @@ const PairActivity: VoidComponent<{ onPaired: () => void }> = (props) => {
           type: 'pairing',
           input: { pairToken },
         }
-      : 'scanning',
+      : 'grant',
     states: {
+      grant(_input, to) {
+        createEffect(() => {
+          console.debug('permission', permission())
+          if (permission() === 'granted') {
+            to.scanning()
+          } else if (permission() === 'prompt') {
+            void createMediaPermissionRequest({ video: true })
+              .then(() => {
+                to.scanning()
+              })
+              .catch((err) => {
+                console.error('Failed to request permission', err)
+              })
+          }
+        })
+        return (
+          <>
+            <TopAppBar trailing={<IconButton name="close" href="/" />}>Add new device</TopAppBar>
+            <div class={clsx('flex flex-col items-center text-center gap-4 px-8 max-w-xs mx-auto text-md')}>
+              <Icon name="camera" size="40" />
+              <Show when={permission() === 'denied'} fallback="Please grant connect permission to use your camera">
+                Camera permission denied - check your browser settings
+              </Show>
+            </div>
+          </>
+        )
+      },
       scanning(_input, to) {
         let videoRef!: HTMLVideoElement
 
+        createEffect(() => {
+          if (permission() !== 'granted') to.grant()
+        })
         onMount(() => {
           const qrScanner = new QrScanner(
             videoRef,
@@ -110,7 +201,7 @@ const PairActivity: VoidComponent<{ onPaired: () => void }> = (props) => {
 
             <div class="flex flex-col items-center gap-4">
               An error occurred: {input.error.message}
-              <Button color="primary" onClick={() => to.scanning()}>
+              <Button color="primary" onClick={() => to.grant()}>
                 Retry
               </Button>
             </div>


### PR DESCRIPTION
Check the camera permission status before opening the QR camera and
prompt the user for permission if necessary. If permission is denied, we
can show a message telling the user to check their browser settings.

Firefox is different from Chrome and doesn't tell us explicitly if
permission is denied. I've "stress tested" switching permissions back
and forth on Firefox and Chrome and it does seem to open the QR scanner
correctly when permission is granted.

- [x] Tested on Chrome and Firefox
- [ ] Tested on Android
- [ ] Tested on Safari/iOS
