### PR TITLE
cleanup: remove API fetched_at and add Device.is_online

### DIFF
--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -37,12 +37,14 @@ const createSharedDevice = (dongleId: string): Device => ({
     prime_data: false,
     nav: false,
   },
-  fetched_at: Math.floor(Date.now() / 1000),
+  is_online: false,
 })
 
 export const getDevice = async (dongleId: string) => {
   try {
-    return await fetcher<Device>(`/v1.1/devices/${dongleId}/`)
+    const device = await fetcher<Device>(`/v1.1/devices/${dongleId}/`)
+    device.is_online = !!device.last_athena_ping && device.last_athena_ping >= Date.now() / 1000 - 120
+    return device
   } catch {
     return createSharedDevice(dongleId)
   }

--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -14,7 +14,7 @@ const sortDevices = (devices: ApiDevice[]) =>
     }
   })
 
-const updateDeviceOnline = (device: ApiDevice): Device => ({
+const createDevice = (device: ApiDevice): Device => ({
   ...device,
   is_online: !!device.last_athena_ping && device.last_athena_ping >= Math.floor(Date.now() / 1000) - 120,
 })
@@ -48,7 +48,7 @@ const createSharedDevice = (dongleId: string): Device => ({
 export const getDevice = async (dongleId: string): Promise<Device> => {
   try {
     const device = await fetcher<ApiDevice>(`/v1.1/devices/${dongleId}/`)
-    return updateDeviceOnline(device)
+    return createDevice(device)
   } catch {
     return createSharedDevice(dongleId)
   }
@@ -66,7 +66,7 @@ export const getDeviceStats = async (dongleId: string) =>
 export const getDevices = async (): Promise<Device[]> =>
   fetcher<ApiDevice[]>('/v1/me/devices/')
     .then(sortDevices)
-    .then((devices) => devices.map(updateDeviceOnline))
+    .then((devices) => devices.map(createDevice))
     .catch(() => [])
 
 export const unpairDevice = async (dongleId: string) =>

--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -43,7 +43,7 @@ const createSharedDevice = (dongleId: string): Device => ({
 export const getDevice = async (dongleId: string) => {
   try {
     const device = await fetcher<Device>(`/v1.1/devices/${dongleId}/`)
-    device.is_online = !!device.last_athena_ping && device.last_athena_ping >= Date.now() / 1000 - 120
+    device.is_online = !!device.last_athena_ping && device.last_athena_ping >= Math.floor(Date.now() / 1000) - 120
     return device
   } catch {
     return createSharedDevice(dongleId)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,13 +1,6 @@
 import { accessToken } from './auth/client'
 import { API_URL } from './config'
 
-const populateFetchedAt = <T>(item: T): T => {
-  return {
-    ...item,
-    fetched_at: Math.floor(Date.now() / 1000),
-  }
-}
-
 export async function fetcher<T>(endpoint: string, init?: RequestInit, apiUrl: string = API_URL): Promise<T> {
   const req = new Request(`${apiUrl}${endpoint}`, {
     ...init,
@@ -31,11 +24,5 @@ export async function fetcher<T>(endpoint: string, init?: RequestInit, apiUrl: s
   if (json.error) {
     throw new Error(`Server error: ${json.description}`, { cause: json })
   }
-  if (Array.isArray(json)) {
-    return json.map(populateFetchedAt) as T
-  } else if (typeof json === 'object') {
-    return populateFetchedAt(json)
-  } else {
-    throw new Error(`Unexpected response type: ${typeof json}. Expected either type array or object.`)
-  }
+  return json
 }

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -15,7 +15,7 @@ export interface DeviceLocation {
   bearing: number
 }
 
-export interface Device {
+export interface ApiDevice {
   dongle_id: string
   alias: string
   serial: string
@@ -36,7 +36,9 @@ export interface Device {
     prime_data: boolean
     nav: boolean
   }
-  // connect custom attributes
+}
+
+export interface Device extends ApiDevice {
   is_online: boolean
 }
 

--- a/src/api/types.d.ts
+++ b/src/api/types.d.ts
@@ -1,7 +1,3 @@
-export interface ApiResponseBase {
-  fetched_at: number
-}
-
 export interface Profile {
   email: string
   id: string
@@ -10,7 +6,7 @@ export interface Profile {
   user_id: string
 }
 
-export interface DeviceLocation extends ApiResponseBase {
+export interface DeviceLocation {
   lat: number
   lng: number
   time: number
@@ -19,7 +15,7 @@ export interface DeviceLocation extends ApiResponseBase {
   bearing: number
 }
 
-export interface Device extends ApiResponseBase {
+export interface Device {
   dongle_id: string
   alias: string
   serial: string
@@ -40,6 +36,8 @@ export interface Device extends ApiResponseBase {
     prime_data: boolean
     nav: boolean
   }
+  // connect custom attributes
+  is_online: boolean
 }
 
 export interface DrivingStatisticsAggregation {
@@ -53,7 +51,7 @@ export interface DrivingStatistics {
   week: DrivingStatisticsAggregation
 }
 
-export interface Route extends ApiResponseBase {
+export interface Route {
   can: boolean
   create_time: number
   devicetype: number
@@ -113,7 +111,7 @@ export interface Files {
 
 export type AthenaOfflineQueueResponse = AthenaOfflineQueueItem<unknown>[]
 
-export interface AthenaOfflineQueueItem<T> extends ApiResponseBase, AthenaCallRequest<T> {
+export interface AthenaOfflineQueueItem<T> extends AthenaCallRequest<T> {
   expiry: number
 }
 

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -11,7 +11,7 @@ import TopAppBar from '~/components/material/TopAppBar'
 import DeviceLocation from '~/components/DeviceLocation'
 import DeviceStatistics from '~/components/DeviceStatistics'
 import UploadQueue from '~/components/UploadQueue'
-import { deviceIsOnline, getDeviceName } from '~/utils/device'
+import { getDeviceName } from '~/utils/device'
 
 import RouteList from '../components/RouteList'
 
@@ -96,12 +96,7 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
           <div class="flex items-center justify-between p-4">
             <Suspense fallback={<div class="h-[32px] skeleton-loader size-full rounded-xs" />}>
               <div class="inline-flex items-center gap-2">
-                <div
-                  class={clsx(
-                    'm-2 size-2 shrink-0 rounded-full',
-                    device.latest && deviceIsOnline(device.latest) ? 'bg-green-400' : 'bg-gray-400',
-                  )}
-                />
+                <div class={clsx('m-2 size-2 shrink-0 rounded-full', device.latest?.is_online ? 'bg-green-400' : 'bg-gray-400')} />
 
                 {<div class="text-lg font-bold">{deviceName()}</div>}
               </div>

--- a/src/pages/dashboard/components/DeviceList.tsx
+++ b/src/pages/dashboard/components/DeviceList.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx'
 import { useDrawerContext } from '~/components/material/Drawer'
 import List, { ListItem, ListItemContent } from '~/components/material/List'
 import type { Device } from '~/api/types'
-import { getDeviceName, deviceIsOnline } from '~/utils/device'
+import { getDeviceName } from '~/utils/device'
 import storage from '~/utils/storage'
 
 type DeviceListProps = {
@@ -30,7 +30,7 @@ const DeviceList: VoidComponent<DeviceListProps> = (props) => {
           {(device) => (
             <ListItem
               variant="nav"
-              leading={<div class={clsx('m-2 size-2 shrink-0 rounded-full', deviceIsOnline(device) ? 'bg-green-400' : 'bg-gray-400')} />}
+              leading={<div class={clsx('m-2 size-2 shrink-0 rounded-full', device.is_online ? 'bg-green-400' : 'bg-gray-400')} />}
               selected={isSelected(device)}
               onClick={onClick(device)}
               href={`/${device.dongle_id}`}

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -4,7 +4,3 @@ export function getDeviceName(device: Device) {
   if (device.alias) return device.alias
   return `comma ${device.device_type}`
 }
-
-export function deviceIsOnline(device: Device) {
-  return !!device.last_athena_ping && device.last_athena_ping >= device.fetched_at - 120
-}


### PR DESCRIPTION
We can just calculate `is_online` when we fetch the device instead of attaching `fetched_at: number` to every API response and re-calculating `isDeviceOnline` in different places