### PR TITLE
refactor(Dashboard): shared data

### DIFF
--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -21,8 +21,8 @@ describe('Demo mode', () => {
   beforeEach(() => setAccessToken(Demo.ACCESS_TOKEN))
 
   test('View dashboard', async () => {
-    const { findByText } = renderApp('/')
-    expect(await findByText('demo 3X')).toBeTruthy()
+    const { findAllByText } = renderApp('/')
+    expect(await findAllByText('demo 3X')).toHaveLength(2)
   })
 
   test('View demo route', async () => {

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -19,7 +19,7 @@ import DeviceActivity from './activities/DeviceActivity'
 import RouteActivity from './activities/RouteActivity'
 import SettingsActivity from './activities/SettingsActivity'
 
-import { devices, profile, setSelectedDongleId } from './data'
+import { devices, profile, setCurrentDongleId } from './data'
 import storage from '~/utils/storage'
 
 const PairActivity = lazy(() => import('./activities/PairActivity'))
@@ -138,7 +138,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
     }
   })
 
-  createEffect(() => setSelectedDongleId(urlState().dongleId))
+  createEffect(() => setCurrentDongleId(urlState().dongleId))
 
   const getDefaultDongleId = () => {
     // Do not redirect if dongle ID already selected

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -138,6 +138,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
     }
   })
 
+  // Synchronise global state with URL
   createEffect(() => setCurrentDongleId(urlState().dongleId))
 
   const getDefaultDongleId = () => {

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx'
 
 import { isSignedIn } from '~/api/auth/client'
 import { USERADMIN_URL } from '~/api/config'
+import storage from '~/utils/storage'
 
 import Button from '~/components/material/Button'
 import ButtonBase from '~/components/material/ButtonBase'
@@ -20,7 +21,6 @@ import RouteActivity from './activities/RouteActivity'
 import SettingsActivity from './activities/SettingsActivity'
 
 import { devices, profile, setCurrentDongleId } from './data'
-import storage from '~/utils/storage'
 
 const PairActivity = lazy(() => import('./activities/PairActivity'))
 

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -13,7 +13,7 @@ import DeviceStatistics from '~/components/DeviceStatistics'
 import UploadQueue from '~/components/UploadQueue'
 
 import RouteList from '../components/RouteList'
-import { selectedDevice as device, selectedDeviceName as deviceName } from '../data'
+import { currentDevice as device, selectedDeviceName as deviceName } from '../data'
 
 type DeviceActivityProps = {
   dongleId: string

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -1,9 +1,9 @@
-import { createResource, createSignal, For, Show, Suspense, type VoidComponent } from 'solid-js'
+import { createSignal, For, Show, Suspense, type VoidComponent } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import clsx from 'clsx'
 
 import { takeSnapshot } from '~/api/athena'
-import { getDevice, SHARED_DEVICE } from '~/api/devices'
+import { SHARED_DEVICE } from '~/api/devices'
 import { DrawerToggleButton, useDrawerContext } from '~/components/material/Drawer'
 import Icon from '~/components/material/Icon'
 import IconButton from '~/components/material/IconButton'
@@ -11,19 +11,15 @@ import TopAppBar from '~/components/material/TopAppBar'
 import DeviceLocation from '~/components/DeviceLocation'
 import DeviceStatistics from '~/components/DeviceStatistics'
 import UploadQueue from '~/components/UploadQueue'
-import { getDeviceName } from '~/utils/device'
 
 import RouteList from '../components/RouteList'
+import { selectedDevice as device, selectedDeviceName as deviceName } from '../data'
 
 type DeviceActivityProps = {
   dongleId: string
 }
 
 const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
-  // TODO: device should be passed in from DeviceList
-  const [device] = createResource(() => props.dongleId, getDevice)
-  // Resource as source of another resource blocks component initialization
-  const deviceName = () => (device.latest ? getDeviceName(device.latest) : '')
   // TODO: remove this. if we're listing the routes for a device you should always be a user, this is for viewing public routes which are being removed
   const isDeviceUser = () => (device.loading ? true : device.latest?.is_owner || device.latest?.alias !== SHARED_DEVICE)
   const [queueVisible, setQueueVisible] = createSignal(false)
@@ -96,7 +92,7 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
           <div class="flex items-center justify-between p-4">
             <Suspense fallback={<div class="h-[32px] skeleton-loader size-full rounded-xs" />}>
               <div class="inline-flex items-center gap-2">
-                <div class={clsx('m-2 size-2 shrink-0 rounded-full', device.latest?.is_online ? 'bg-green-400' : 'bg-gray-400')} />
+                <div class={clsx('m-2 size-2 shrink-0 rounded-full', device()?.is_online ? 'bg-green-400' : 'bg-gray-400')} />
 
                 {<div class="text-lg font-bold">{deviceName()}</div>}
               </div>

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -13,7 +13,7 @@ import DeviceStatistics from '~/components/DeviceStatistics'
 import UploadQueue from '~/components/UploadQueue'
 
 import RouteList from '../components/RouteList'
-import { currentDevice as device, selectedDeviceName as deviceName } from '../data'
+import { currentDevice as device, currentDeviceName as deviceName } from '../data'
 
 type DeviceActivityProps = {
   dongleId: string

--- a/src/pages/dashboard/activities/PairActivity.tsx
+++ b/src/pages/dashboard/activities/PairActivity.tsx
@@ -9,6 +9,7 @@ import Icon from '~/components/material/Icon'
 import IconButton from '~/components/material/IconButton'
 import TopAppBar from '~/components/material/TopAppBar'
 
+import { refetchDevices } from '../data'
 import './PairActivity.css'
 
 const toError = (error: unknown): Error => {
@@ -17,7 +18,7 @@ const toError = (error: unknown): Error => {
   return new Error('An unknown error occurred', { cause: error })
 }
 
-const PairActivity: VoidComponent<{ onPaired: () => void }> = (props) => {
+const PairActivity: VoidComponent = () => {
   const { pair } = useLocation().query
   const pairToken: string | undefined = Array.isArray(pair) ? pair[0] : pair
 
@@ -85,7 +86,7 @@ const PairActivity: VoidComponent<{ onPaired: () => void }> = (props) => {
 
         pairDevice(input.pairToken)
           .then((dongleId) => navigate(`/${dongleId}`))
-          .then(props.onPaired)
+          .then(() => refetchDevices())
           .catch((reason) => {
             const error = toError(reason)
             console.error('Error pairing device', error, error.cause)

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -16,7 +16,7 @@ import RouteVideoPlayer from '~/components/RouteVideoPlayer'
 import RouteUploadButtons from '~/components/RouteUploadButtons'
 import Timeline from '~/components/Timeline'
 
-import { profile, selectedDevice as device } from '../data'
+import { profile, currentDevice as device } from '../data'
 
 type RouteActivityProps = {
   dongleId: string

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -1,8 +1,8 @@
 import { Show, createEffect, createResource, createSignal, Suspense, type VoidComponent } from 'solid-js'
+import { A } from '@solidjs/router'
 
 import { setRouteViewed } from '~/api/athena'
-import { getDevice } from '~/api/devices'
-import { getProfile } from '~/api/profile'
+import { generateRouteStatistics, getTimelineEvents } from '~/api/derived'
 import { getRoute } from '~/api/route'
 import { dayjs } from '~/utils/format'
 import { resolved } from '~/utils/reactivity'
@@ -15,8 +15,8 @@ import RouteStatisticsBar from '~/components/RouteStatisticsBar'
 import RouteVideoPlayer from '~/components/RouteVideoPlayer'
 import RouteUploadButtons from '~/components/RouteUploadButtons'
 import Timeline from '~/components/Timeline'
-import { generateRouteStatistics, getTimelineEvents } from '~/api/derived'
-import { A } from '@solidjs/router'
+
+import { profile, selectedDevice as device } from '../data'
 
 type RouteActivityProps = {
   dongleId: string
@@ -53,8 +53,6 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
     onTimelineChange(props.startTime)
   })
 
-  const [device] = createResource(() => props.dongleId, getDevice)
-  const [profile] = createResource(getProfile)
   createEffect(() => {
     if (!resolved(device) || !resolved(profile) || (!device().is_owner && !profile().superuser)) return
     void setRouteViewed(device().dongle_id, props.dateStr)

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -3,7 +3,7 @@ import type { Accessor, VoidComponent, Setter, ParentComponent, Resource, JSXEle
 import { useLocation } from '@solidjs/router'
 import clsx from 'clsx'
 
-import { getDevice, unpairDevice } from '~/api/devices'
+import { unpairDevice } from '~/api/devices'
 import {
   cancelSubscription,
   getStripeCheckout,
@@ -22,6 +22,8 @@ import IconButton from '~/components/material/IconButton'
 import TopAppBar from '~/components/material/TopAppBar'
 import { createQuery } from '~/utils/createQuery'
 import { getDeviceName } from '~/utils/device'
+
+import { selectedDevice as device } from '../data'
 
 const useAction = <T,>(action: () => Promise<T>): [() => void, Resource<T>] => {
   const [source, setSource] = createSignal(false)
@@ -95,7 +97,6 @@ const PrimeCheckout: VoidComponent<{ dongleId: string }> = (props) => {
   const [selectedPlan, setSelectedPlan] = createSignal<PrimePlan>()
 
   const dongleId = () => props.dongleId
-  const [device] = createResource(dongleId, getDevice)
   const [subscribeInfo] = createResource(dongleId, getSubscribeInfo)
 
   const stripeCancelled = () => new URLSearchParams(useLocation().search).has('stripe_cancelled')
@@ -425,8 +426,6 @@ const DeviceSettingsForm: VoidComponent<{ dongleId: string; device: Resource<Dev
 }
 
 const SettingsActivity: VoidComponent<PrimeActivityProps> = (props) => {
-  const [device] = createResource(() => props.dongleId, getDevice)
-
   return (
     <>
       <TopAppBar component="h2" leading={<IconButton class="md:hidden" name="arrow_back" href={`/${props.dongleId}`} />}>

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -23,7 +23,7 @@ import TopAppBar from '~/components/material/TopAppBar'
 import { createQuery } from '~/utils/createQuery'
 import { getDeviceName } from '~/utils/device'
 
-import { selectedDevice as device } from '../data'
+import { currentDevice as device } from '../data'
 
 const useAction = <T,>(action: () => Promise<T>): [() => void, Resource<T>] => {
   const [source, setSource] = createSignal(false)

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -21,9 +21,8 @@ import Icon from '~/components/material/Icon'
 import IconButton from '~/components/material/IconButton'
 import TopAppBar from '~/components/material/TopAppBar'
 import { createQuery } from '~/utils/createQuery'
-import { getDeviceName } from '~/utils/device'
 
-import { currentDevice as device } from '../data'
+import { currentDevice as device, currentDeviceName as deviceName } from '../data'
 
 const useAction = <T,>(action: () => Promise<T>): [() => void, Resource<T>] => {
   const [source, setSource] = createSignal(false)
@@ -402,8 +401,6 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
 }
 
 const DeviceSettingsForm: VoidComponent<{ dongleId: string; device: Resource<Device> }> = (props) => {
-  const [deviceName] = createResource(props.device, getDeviceName)
-
   const [unpair, unpairData] = useAction(async () => {
     const { success } = await unpairDevice(props.dongleId)
     if (success) window.location.href = window.location.origin

--- a/src/pages/dashboard/components/DeviceList.tsx
+++ b/src/pages/dashboard/components/DeviceList.tsx
@@ -1,5 +1,4 @@
 import { For, Suspense, type VoidComponent } from 'solid-js'
-import { useLocation } from '@solidjs/router'
 import clsx from 'clsx'
 
 import { useDrawerContext } from '~/components/material/Drawer'
@@ -8,16 +7,16 @@ import type { Device } from '~/api/types'
 import { getDeviceName } from '~/utils/device'
 import storage from '~/utils/storage'
 
+import { devices, selectedDongleId } from '../data'
+
 type DeviceListProps = {
   class?: string
-  devices: Device[] | undefined
 }
 
 const DeviceList: VoidComponent<DeviceListProps> = (props) => {
-  const location = useLocation()
   const { setOpen } = useDrawerContext()
 
-  const isSelected = (device: Device) => location.pathname.includes(device.dongle_id)
+  const isSelected = (device: Device) => selectedDongleId() === device.dongle_id
   const onClick = (device: Device) => () => {
     setOpen(false)
     storage.setItem('lastSelectedDongleId', device.dongle_id)
@@ -26,7 +25,7 @@ const DeviceList: VoidComponent<DeviceListProps> = (props) => {
   return (
     <List variant="nav" class={props.class}>
       <Suspense fallback={<div class="h-14 skeleton-loader rounded-xl" />}>
-        <For each={props.devices} fallback={<span class="text-md mx-2 text-on-surface-variant">No devices found</span>}>
+        <For each={devices()} fallback={<span class="text-md mx-2 text-on-surface-variant">No devices found</span>}>
           {(device) => (
             <ListItem
               variant="nav"

--- a/src/pages/dashboard/components/DeviceList.tsx
+++ b/src/pages/dashboard/components/DeviceList.tsx
@@ -7,7 +7,7 @@ import type { Device } from '~/api/types'
 import { getDeviceName } from '~/utils/device'
 import storage from '~/utils/storage'
 
-import { devices, selectedDongleId } from '../data'
+import { devices, currentDongleId } from '../data'
 
 type DeviceListProps = {
   class?: string
@@ -16,7 +16,7 @@ type DeviceListProps = {
 const DeviceList: VoidComponent<DeviceListProps> = (props) => {
   const { setOpen } = useDrawerContext()
 
-  const isSelected = (device: Device) => selectedDongleId() === device.dongle_id
+  const isSelected = (device: Device) => currentDongleId() === device.dongle_id
   const onClick = (device: Device) => () => {
     setOpen(false)
     storage.setItem('lastSelectedDongleId', device.dongle_id)

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -1,4 +1,4 @@
-import { createResource, createSignal } from 'solid-js'
+import { createMemo, createResource, createSignal } from 'solid-js'
 
 import { accessToken } from '~/api/auth/client'
 import { getDevice, getDevices } from '~/api/devices'
@@ -25,4 +25,8 @@ const refetchCurrentDevice = () => {
 }
 export { currentDevice, refetchCurrentDevice }
 
-export const [currentDeviceName] = createResource(currentDevice, getDeviceName)
+export const currentDeviceName = createMemo(() => {
+  const device = currentDevice()
+  if (!device) return ''
+  return getDeviceName(device)
+})

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -1,0 +1,31 @@
+import { createResource, createSignal } from 'solid-js'
+
+import { accessToken } from '~/api/auth/client'
+import { getDevice, getDevices } from '~/api/devices'
+import { getProfile } from '~/api/profile'
+import { getDeviceName } from '~/utils/device'
+import { resolved } from '~/utils/reactivity'
+
+const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile)
+export { profile, refetchProfile }
+
+const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices)
+export { devices, refetchDevices }
+
+const [selectedDongleId, setSelectedDongleId] = createSignal<string>()
+export { selectedDongleId, setSelectedDongleId }
+
+const [selectedDevice, { refetch: _refetchSelectedDevice }] = createResource(selectedDongleId, (dongleId) => {
+  const device = resolved(devices) ? devices.latest.find((device) => device.dongle_id === dongleId) : undefined
+  if (device) return device
+  return getDevice(dongleId)
+})
+const refetchSelectedDevice = () => {
+  const dongleId = selectedDongleId()
+  if (!dongleId) return
+  if (resolved(devices) && devices.latest.some((device) => device.dongle_id === dongleId)) return refetchDevices()
+  return _refetchSelectedDevice()
+}
+export { selectedDevice, refetchSelectedDevice }
+
+export const [selectedDeviceName] = createResource(selectedDevice, getDeviceName)

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -1,63 +1,28 @@
-import { createMemo, createResource, type Signal } from 'solid-js'
-import { createStore, reconcile, unwrap } from 'solid-js/store'
+import { createResource, createSignal } from 'solid-js'
 
 import { accessToken } from '~/api/auth/client'
 import { getDevice, getDevices } from '~/api/devices'
 import { getProfile } from '~/api/profile'
-import type { Device, Profile } from '~/api/types'
 import { getDeviceName } from '~/utils/device'
+import { resolved } from '~/utils/reactivity'
 
-interface State {
-  profile?: Profile
-  devices?: Device[]
-  currentDongleId?: string
-  currentDevice?: Device
-}
+export const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile)
 
-const [state, setState] = createStore<State>()
+export const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices)
 
-const createStorage =
-  <K extends keyof State>(key: K) =>
-  <T extends State[K]>(value: T): Signal<T> => {
-    setState(key, value)
-    return [
-      () => state[key],
-      (v: T | ((prev: T) => T)) => {
-        const unwrapped = unwrap(state[key]) as T
-        if (typeof v === 'function') v = v(unwrapped)
-        setState(key, reconcile(v))
-        return state[key]
-      },
-    ] as Signal<T>
-  }
-
-export const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile, {
-  storage: createStorage('profile'),
-})
-
-export const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices, {
-  storage: createStorage('devices'),
-})
-
-export const currentDongleId = () => state.currentDongleId
-export const setCurrentDongleId = (dongleId: string | undefined) => {
-  setState('currentDongleId', dongleId)
-}
+export const [currentDongleId, setCurrentDongleId] = createSignal<string>()
 
 const [currentDevice, { refetch: _refetchCurrentDevice }] = createResource(currentDongleId, (dongleId) => {
-  const device = state.devices?.find((device) => device.dongle_id === dongleId)
+  const device = resolved(devices) ? devices.latest.find((device) => device.dongle_id === dongleId) : undefined
   if (device) return device
   return getDevice(dongleId)
 })
 const refetchCurrentDevice = () => {
-  const dongleId = state.currentDongleId
+  const dongleId = currentDongleId()
   if (!dongleId) return
-  if (state.devices?.some((device) => device.dongle_id === dongleId)) return refetchDevices()
+  if (resolved(devices) && devices.latest.some((device) => device.dongle_id === dongleId)) return refetchDevices()
   return _refetchCurrentDevice()
 }
 export { currentDevice, refetchCurrentDevice }
 
-export const currentDeviceName = createMemo(() => {
-  const device = currentDevice()
-  return device ? getDeviceName(device) : ''
-})
+export const [currentDeviceName] = createResource(currentDevice, getDeviceName)

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -6,7 +6,7 @@ import { getProfile } from '~/api/profile'
 import { getDeviceName } from '~/utils/device'
 import { resolved } from '~/utils/reactivity'
 
-export const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile)
+export const [profile, { refetch: refetchProfile }] = createResource(accessToken, () => getProfile().catch(() => undefined))
 
 export const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices)
 

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -6,24 +6,17 @@ import { getProfile } from '~/api/profile'
 import { getDeviceName } from '~/utils/device'
 import { resolved } from '~/utils/reactivity'
 
-export const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile)
+export const [profile] = createResource(accessToken, getProfile)
 
 export const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices)
 
 export const [currentDongleId, setCurrentDongleId] = createSignal<string>()
 
-const [currentDevice, { refetch: _refetchCurrentDevice }] = createResource(currentDongleId, (dongleId) => {
+export const [currentDevice] = createResource(currentDongleId, (dongleId) => {
   const device = resolved(devices) ? devices().find((device) => device.dongle_id === dongleId) : undefined
   if (device) return device
   return getDevice(dongleId)
 })
-const refetchCurrentDevice = () => {
-  const dongleId = currentDongleId()
-  if (!dongleId) return
-  if (resolved(devices) && devices().some((device) => device.dongle_id === dongleId)) return refetchDevices()
-  return _refetchCurrentDevice()
-}
-export { currentDevice, refetchCurrentDevice }
 
 export const currentDeviceName = createMemo(() => {
   const device = currentDevice()

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -6,7 +6,7 @@ import { getProfile } from '~/api/profile'
 import { getDeviceName } from '~/utils/device'
 import { resolved } from '~/utils/reactivity'
 
-export const [profile, { refetch: refetchProfile }] = createResource(accessToken, () => getProfile().catch(() => undefined))
+export const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile)
 
 export const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices)
 

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -12,20 +12,20 @@ export { profile, refetchProfile }
 const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices)
 export { devices, refetchDevices }
 
-const [selectedDongleId, setSelectedDongleId] = createSignal<string>()
-export { selectedDongleId, setSelectedDongleId }
+const [currentDongleId, setCurrentDongleId] = createSignal<string>()
+export { currentDongleId, setCurrentDongleId }
 
-const [selectedDevice, { refetch: _refetchSelectedDevice }] = createResource(selectedDongleId, (dongleId) => {
+const [currentDevice, { refetch: _refetchCurrentDevice }] = createResource(currentDongleId, (dongleId) => {
   const device = resolved(devices) ? devices.latest.find((device) => device.dongle_id === dongleId) : undefined
   if (device) return device
   return getDevice(dongleId)
 })
-const refetchSelectedDevice = () => {
-  const dongleId = selectedDongleId()
+const refetchCurrentDevice = () => {
+  const dongleId = currentDongleId()
   if (!dongleId) return
   if (resolved(devices) && devices.latest.some((device) => device.dongle_id === dongleId)) return refetchDevices()
-  return _refetchSelectedDevice()
+  return _refetchCurrentDevice()
 }
-export { selectedDevice, refetchSelectedDevice }
+export { currentDevice, refetchCurrentDevice }
 
-export const [selectedDeviceName] = createResource(selectedDevice, getDeviceName)
+export const [selectedDeviceName] = createResource(currentDevice, getDeviceName)

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -13,14 +13,14 @@ export const [devices, { refetch: refetchDevices }] = createResource(accessToken
 export const [currentDongleId, setCurrentDongleId] = createSignal<string>()
 
 const [currentDevice, { refetch: _refetchCurrentDevice }] = createResource(currentDongleId, (dongleId) => {
-  const device = resolved(devices) ? devices.latest.find((device) => device.dongle_id === dongleId) : undefined
+  const device = resolved(devices) ? devices().find((device) => device.dongle_id === dongleId) : undefined
   if (device) return device
   return getDevice(dongleId)
 })
 const refetchCurrentDevice = () => {
   const dongleId = currentDongleId()
   if (!dongleId) return
-  if (resolved(devices) && devices.latest.some((device) => device.dongle_id === dongleId)) return refetchDevices()
+  if (resolved(devices) && devices().some((device) => device.dongle_id === dongleId)) return refetchDevices()
   return _refetchCurrentDevice()
 }
 export { currentDevice, refetchCurrentDevice }

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -1,28 +1,63 @@
-import { createResource, createSignal } from 'solid-js'
+import { createMemo, createResource, type Signal } from 'solid-js'
+import { createStore, reconcile, unwrap } from 'solid-js/store'
 
 import { accessToken } from '~/api/auth/client'
 import { getDevice, getDevices } from '~/api/devices'
 import { getProfile } from '~/api/profile'
+import type { Device, Profile } from '~/api/types'
 import { getDeviceName } from '~/utils/device'
-import { resolved } from '~/utils/reactivity'
 
-export const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile)
+interface State {
+  profile?: Profile
+  devices?: Device[]
+  currentDongleId?: string
+  currentDevice?: Device
+}
 
-export const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices)
+const [state, setState] = createStore<State>()
 
-export const [currentDongleId, setCurrentDongleId] = createSignal<string>()
+const createStorage =
+  <K extends keyof State>(key: K) =>
+  <T extends State[K]>(value: T): Signal<T> => {
+    setState(key, value)
+    return [
+      () => state[key],
+      (v: T | ((prev: T) => T)) => {
+        const unwrapped = unwrap(state[key]) as T
+        if (typeof v === 'function') v = v(unwrapped)
+        setState(key, reconcile(v))
+        return state[key]
+      },
+    ] as Signal<T>
+  }
+
+export const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile, {
+  storage: createStorage('profile'),
+})
+
+export const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices, {
+  storage: createStorage('devices'),
+})
+
+export const currentDongleId = () => state.currentDongleId
+export const setCurrentDongleId = (dongleId: string | undefined) => {
+  setState('currentDongleId', dongleId)
+}
 
 const [currentDevice, { refetch: _refetchCurrentDevice }] = createResource(currentDongleId, (dongleId) => {
-  const device = resolved(devices) ? devices.latest.find((device) => device.dongle_id === dongleId) : undefined
+  const device = state.devices?.find((device) => device.dongle_id === dongleId)
   if (device) return device
   return getDevice(dongleId)
 })
 const refetchCurrentDevice = () => {
-  const dongleId = currentDongleId()
+  const dongleId = state.currentDongleId
   if (!dongleId) return
-  if (resolved(devices) && devices.latest.some((device) => device.dongle_id === dongleId)) return refetchDevices()
+  if (state.devices?.some((device) => device.dongle_id === dongleId)) return refetchDevices()
   return _refetchCurrentDevice()
 }
 export { currentDevice, refetchCurrentDevice }
 
-export const [currentDeviceName] = createResource(currentDevice, getDeviceName)
+export const currentDeviceName = createMemo(() => {
+  const device = currentDevice()
+  return device ? getDeviceName(device) : ''
+})

--- a/src/pages/dashboard/data.ts
+++ b/src/pages/dashboard/data.ts
@@ -6,14 +6,11 @@ import { getProfile } from '~/api/profile'
 import { getDeviceName } from '~/utils/device'
 import { resolved } from '~/utils/reactivity'
 
-const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile)
-export { profile, refetchProfile }
+export const [profile, { refetch: refetchProfile }] = createResource(accessToken, getProfile)
 
-const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices)
-export { devices, refetchDevices }
+export const [devices, { refetch: refetchDevices }] = createResource(accessToken, getDevices)
 
-const [currentDongleId, setCurrentDongleId] = createSignal<string>()
-export { currentDongleId, setCurrentDongleId }
+export const [currentDongleId, setCurrentDongleId] = createSignal<string>()
 
 const [currentDevice, { refetch: _refetchCurrentDevice }] = createResource(currentDongleId, (dongleId) => {
   const device = resolved(devices) ? devices.latest.find((device) => device.dongle_id === dongleId) : undefined
@@ -28,4 +25,4 @@ const refetchCurrentDevice = () => {
 }
 export { currentDevice, refetchCurrentDevice }
 
-export const [selectedDeviceName] = createResource(currentDevice, getDeviceName)
+export const [currentDeviceName] = createResource(currentDevice, getDeviceName)

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,7 +1,6 @@
 import type { Device } from '~/api/types'
 
-export function getDeviceName(device: Device | undefined) {
-  if (!device) return ''
+export function getDeviceName(device: Device) {
   if (device.alias) return device.alias
   return `comma ${device.device_type}`
 }

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,6 +1,7 @@
 import type { Device } from '~/api/types'
 
-export function getDeviceName(device: Device) {
+export function getDeviceName(device: Device | undefined) {
+  if (!device) return ''
   if (device.alias) return device.alias
   return `comma ${device.device_type}`
 }


### PR DESCRIPTION
This removes a couple of duplicate API fetches for profile, devices and the current device. If the current device is in the list already returned (my devices) then that will be used instead, too.

19 requests to api.comma.ai down from 23 (including OPTIONS) on the demo route
https://579.connect-d5y.pages.dev/1d3dc3e03047b0c7/2023-07-27--13-01-19