### PR TITLE
fix(Button): improved text btn contrast

### DIFF
--- a/src/components/material/Button.tsx
+++ b/src/components/material/Button.tsx
@@ -17,7 +17,7 @@ const Button: ParentComponent<ButtonProps> = (props) => {
   const color = () => props.color || 'primary'
   const colorClasses = () =>
     ({
-      text: 'text-primary before:bg-on-primary',
+      text: 'text-primary before:bg-primary',
       primary: 'bg-primary before:bg-on-primary text-on-primary hover:elevation-1',
       secondary: 'bg-secondary before:bg-on-secondary text-on-secondary hover:elevation-1',
       tertiary: 'bg-tertiary before:bg-on-tertiary text-on-tertiary hover:elevation-1',
@@ -31,8 +31,7 @@ const Button: ParentComponent<ButtonProps> = (props) => {
       class={clsx(
         'state-layer inline-flex h-10 shrink-0 items-center justify-center gap-2 rounded-full py-1 contrast-100 transition',
         colorClasses(),
-        disabled() && 'cursor-not-allowed opacity-50',
-        !disabled() && 'hover:opacity-80',
+        disabled() && 'cursor-not-allowed opacity-40',
         props.leading ? 'pl-4' : 'pl-6',
         props.trailing ? 'pr-4' : 'pr-6',
         props.class,

--- a/src/components/material/Button.tsx
+++ b/src/components/material/Button.tsx
@@ -31,7 +31,8 @@ const Button: ParentComponent<ButtonProps> = (props) => {
       class={clsx(
         'state-layer inline-flex h-10 shrink-0 items-center justify-center gap-2 rounded-full py-1 contrast-100 transition',
         colorClasses(),
-        disabled() && 'cursor-not-allowed opacity-40',
+        disabled() && 'cursor-not-allowed opacity-50',
+        !disabled() && 'hover:opacity-80',
         props.leading ? 'pl-4' : 'pl-6',
         props.trailing ? 'pr-4' : 'pr-6',
         props.class,


### PR DESCRIPTION
- ~~We set the background colour on hover, changing opacity makes that harder to see~~ will fix separately
- Improved bg color for text button (fixes "Cancel all" contrast) (matches [spec](https://m3.material.io/components/buttons/specs#398d84eb-fc8a-4c8a-bfb4-82d2e85dee4d))