### PR TITLE
refactor(Dialog): add component, update design

### DIFF
--- a/src/components/material/Dialog.tsx
+++ b/src/components/material/Dialog.tsx
@@ -1,0 +1,52 @@
+import { type ParentComponent, createEffect, onMount, onCleanup } from 'solid-js'
+import clsx from 'clsx'
+
+type DialogProps = {
+  class?: string
+  open: boolean
+  onClose?: () => void
+}
+
+const Dialog: ParentComponent<DialogProps> = (props) => {
+  let dialogRef: HTMLDialogElement | undefined
+
+  createEffect(() => {
+    if (!dialogRef) return
+    if (props.open) {
+      dialogRef.showModal()
+    } else if (dialogRef.open) {
+      dialogRef.close()
+    }
+  })
+
+  const handleDialogClose = () => {
+    if (props.open) props.onClose?.()
+  }
+
+  onMount(() => {
+    if (!dialogRef) return
+    dialogRef.addEventListener('close', handleDialogClose)
+    onCleanup(() => dialogRef?.removeEventListener('close', handleDialogClose))
+  })
+
+  return (
+    <dialog
+      ref={dialogRef}
+      class="fixed inset-0 max-w-[unset] z-50 flex flex-col items-center justify-center bg-transparent backdrop:bg-scrim/[.32] size-full m-0 max-h-[unset]"
+      onClick={() => dialogRef?.close()}
+    >
+      <div
+        class={clsx(
+          'flex w-full flex-col justify-center gap-4 bg-surface-container text-on-surface p-6',
+          'sm:max-w-lg sm:rounded-lg sm:shadow-lg',
+          props.class,
+        )}
+        onClick={(ev) => ev.stopPropagation()}
+      >
+        {props.children}
+      </div>
+    </dialog>
+  )
+}
+
+export default Dialog

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -16,6 +16,7 @@ import { formatDate } from '~/utils/format'
 
 import ButtonBase from '~/components/material/ButtonBase'
 import Button from '~/components/material/Button'
+import Dialog from '~/components/material/Dialog'
 import Icon from '~/components/material/Icon'
 import IconButton from '~/components/material/IconButton'
 import TextField from '~/components/material/TextField'
@@ -370,31 +371,26 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
       </Suspense>
 
       <Show when={cancelDialog()}>
-        <div
-          class="bg-scrim/10 fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm"
-          onClick={() => setCancelDialog(false)}
-        >
-          <div class="flex size-full flex-col gap-4 bg-surface-container p-6 sm:h-auto sm:max-w-lg sm:rounded-lg sm:shadow-lg">
-            <h2 class="text-lg">Cancel subscription?</h2>
-            <p class="text-sm">Your subscription will end immediately, and you will receive a pro-rated refund.</p>
-            <div class="mt-4 flex flex-wrap justify-end gap-2">
-              <Button color="text" disabled={loading()} onClick={() => setCancelDialog(false)}>
-                Not now
-              </Button>
-              <Button
-                color="text"
-                disabled={loading()}
-                loading={cancelData.loading}
-                onClick={() => {
-                  cancel()
-                  setCancelDialog(false)
-                }}
-              >
-                Cancel subscription
-              </Button>
-            </div>
+        <Dialog open={cancelDialog()} onClose={() => setCancelDialog(false)}>
+          <h2 class="text-lg">Cancel subscription?</h2>
+          <p class="text-sm">Your subscription will end immediately, and you will receive a pro-rated refund.</p>
+          <div class="mt-4 flex flex-wrap justify-end gap-2">
+            <Button color="text" disabled={loading()} onClick={() => setCancelDialog(false)}>
+              Not now
+            </Button>
+            <Button
+              color="text"
+              disabled={loading()}
+              loading={cancelData.loading}
+              onClick={() => {
+                cancel()
+                setCancelDialog(false)
+              }}
+            >
+              Cancel subscription
+            </Button>
           </div>
-        </div>
+        </Dialog>
       </Show>
     </div>
   )


### PR DESCRIPTION
Adds a reusable Dialog component (intended for other actions like unpairing)

- On mobile it no longer unnecessarily takes up the entire screen height
- Supports closing with escape key press (thanks to native `<dialog>` element)

| mobile | web |
| --- | --- |
|![Screen Shot 2025-04-15 at 16 53 40](https://github.com/user-attachments/assets/13faabd1-2fce-4417-a574-8a1d85bbf4d8) | ![Screen Shot 2025-04-15 at 16 58 54](https://github.com/user-attachments/assets/5608b6ab-ec4a-42d2-ab60-97c4ac116f91) | 

