### PR TITLE
fix(Dialog): remove flex class, hidden by default

### DIFF
--- a/src/components/material/Dialog.tsx
+++ b/src/components/material/Dialog.tsx
@@ -26,19 +26,21 @@ const Dialog: ParentComponent<DialogProps> = (props) => {
   return (
     <dialog
       ref={dialogRef}
-      class="fixed inset-0 max-w-[unset] z-50 flex flex-col items-center justify-center bg-transparent backdrop:bg-scrim/[.32] size-full m-0 max-h-[unset]"
+      class="fixed inset-0 max-w-[unset] z-50 bg-transparent backdrop:bg-scrim/[.32] size-full max-h-[unset]"
       onClick={() => dialogRef?.close()}
       onClose={handleDialogClose}
     >
-      <div
-        class={clsx(
-          'flex w-full flex-col justify-center gap-4 bg-surface-container text-on-surface p-6',
-          'sm:max-w-lg sm:rounded-lg sm:shadow-lg',
-          props.class,
-        )}
-        onClick={(ev) => ev.stopPropagation()}
-      >
-        {props.children}
+      <div class="flex flex-col size-full items-center">
+        <div
+          class={clsx(
+            'flex w-full flex-col justify-center gap-4 bg-surface-container text-on-surface p-6 m-auto',
+            'sm:max-w-lg sm:rounded-lg sm:shadow-lg',
+            props.class,
+          )}
+          onClick={(ev) => ev.stopPropagation()}
+        >
+          {props.children}
+        </div>
       </div>
     </dialog>
   )

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -370,28 +370,26 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
         </Switch>
       </Suspense>
 
-      <Show when={cancelDialog()}>
-        <Dialog open={cancelDialog()} onClose={() => setCancelDialog(false)}>
-          <h2 class="text-lg">Cancel subscription?</h2>
-          <p class="text-sm">Your subscription will end immediately, and you will receive a pro-rated refund.</p>
-          <div class="mt-4 flex flex-wrap justify-end gap-2">
-            <Button color="text" disabled={loading()} onClick={() => setCancelDialog(false)}>
-              Not now
-            </Button>
-            <Button
-              color="text"
-              disabled={loading()}
-              loading={cancelData.loading}
-              onClick={() => {
-                cancel()
-                setCancelDialog(false)
-              }}
-            >
-              Cancel subscription
-            </Button>
-          </div>
-        </Dialog>
-      </Show>
+      <Dialog open={cancelDialog()} onClose={() => setCancelDialog(false)}>
+        <h2 class="text-lg">Cancel subscription?</h2>
+        <p class="text-sm">Your subscription will end immediately, and you will receive a pro-rated refund.</p>
+        <div class="mt-4 flex flex-wrap justify-end gap-2">
+          <Button color="text" disabled={loading()} onClick={() => setCancelDialog(false)}>
+            Not now
+          </Button>
+          <Button
+            color="text"
+            disabled={loading()}
+            loading={cancelData.loading}
+            onClick={() => {
+              cancel()
+              setCancelDialog(false)
+            }}
+          >
+            Cancel subscription
+          </Button>
+        </div>
+      </Dialog>
     </div>
   )
 }


### PR DESCRIPTION
Eliminate the need to use `<Show>` by fixing the styles on `<dialog>`: the `flex` class caused the dialog to be visible all the time. Nesting the content inside an additional div allows us to center the content without applying `flex` to the `<dialog>` element.