### PR TITLE
feat(Device): add battery voltage indicator

### DIFF
--- a/src/components/material/Icon.tsx
+++ b/src/components/material/Icon.tsx
@@ -8,7 +8,7 @@ export const Icons = [
   'add', 'arrow_back', 'camera', 'check', 'chevron_right', 'clear', 'close', 'delete', 'description', 'directions_car', 'download', 'error',
   'file_copy', 'flag', 'info', 'keyboard_arrow_down', 'keyboard_arrow_up', 'local_fire_department', 'logout', 'menu', 'my_location',
   'open_in_new', 'payments', 'person', 'progress_activity', 'satellite_alt', 'search', 'settings', 'upload', 'videocam', 'refresh',
-  'login', 'person_off', 'autorenew', 'close_small', 'pause', 'play_arrow', 'clear_all',
+  'login', 'person_off', 'autorenew', 'close_small', 'pause', 'play_arrow', 'clear_all', 'bolt',
 ] as const
 
 export type IconName = (typeof Icons)[number]


### PR DESCRIPTION
closes #433

| online | loading | offline |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/af7c6a14-115c-4541-857e-5f1706cca254) | ![image](https://github.com/user-attachments/assets/aae20b26-dde6-4749-a89e-d63271255bb7) | ![image](https://github.com/user-attachments/assets/6eda7b5a-ceb8-4959-876c-d75be8c814c3) |

For an extra 10 lines we can cache the results between changing device, but not sure it's worth it for this specific thing - not sure whether we are trying to replace tanstack or not
