### PR TITLE
perf(store): wait for device list fetch if pending

### DIFF
--- a/src/pages/dashboard/store.ts
+++ b/src/pages/dashboard/store.ts
@@ -16,6 +16,7 @@ const [currentDevice, { refetch: _refetchCurrentDevice }] = createResource(
   () => {
     const dongleId = currentDongleId()
     if (!dongleId) return null
+    if (devices.state === 'unresolved' || devices.state === 'pending') return null
     return { dongleId, devices: resolved(devices) ? devices.latest : null }
   },
   ({ dongleId, devices }) => {


### PR DESCRIPTION
Previously, when requesting a device, we checked if it was already present in the device list to avoid redundant fetches. However, on initial page load, the device list might not have been fetched yet, causing an unnecessary fetch regardless of whether the device is eventually found in the list.

This change ensures we wait for the device list to resolve if it's in a pending or unresolved state to reduce redundant fetches. There is a minor trade-off: a slight delay in fetching devices not in the list on initial load. However, in other cases where the list is already resolved, the fetch is immediate.