### PR TITLE
Note Pair Device in Settings in NoDeviceUpsell

### DIFF
--- a/src/components/DriveView/NoDeviceUpsell.jsx
+++ b/src/components/DriveView/NoDeviceUpsell.jsx
@@ -13,7 +13,7 @@ const NoDeviceUpsell = () => (
       <ul className="my-0">
         <li>Your device is connected to the internet</li>
         <li>You have installed the latest version of openpilot</li>
-        <li>You may need to look for "Pair Device" in Settings</li>
+        <li>You may need to look for &quot;Pair Device&quot; in Settings</li>
       </ul>
       <p>
         If you still cannot see a QR code, your device may already be paired to

--- a/src/components/DriveView/NoDeviceUpsell.jsx
+++ b/src/components/DriveView/NoDeviceUpsell.jsx
@@ -13,6 +13,7 @@ const NoDeviceUpsell = () => (
       <ul className="my-0">
         <li>Your device is connected to the internet</li>
         <li>You have installed the latest version of openpilot</li>
+        <li>You may need to look for "Pair Device" in Settings</li>
       </ul>
       <p>
         If you still cannot see a QR code, your device may already be paired to


### PR DESCRIPTION
Modern OP/Forks isn't so upfront with showing the QR Code in the home screen. Note it might be in settings.