### PR TITLE
Fix flags not showing properly

### DIFF
--- a/src/actions/cached.js
+++ b/src/actions/cached.js
@@ -260,6 +260,7 @@ function parseEvents(route, driveEvents) {
 }
 
 export function fetchEvents(route) {
+  console.log('fetching events for route', route.fullname);
   return async (dispatch, getState) => {
     const state = getState();
     if (!state.routes) {
@@ -293,6 +294,7 @@ export function fetchEvents(route) {
     if (!USE_LOCAL_EVENTS_DATA) {
       // in cache?
       const cacheEvents = await getCacheItem('events', route.fullname, route.maxqlog);
+      console.log('cacheEvents', cacheEvents);
       if (cacheEvents !== null) {
         dispatch({
           type: Types.ACTION_UPDATE_ROUTE_EVENTS,

--- a/src/actions/cached.js
+++ b/src/actions/cached.js
@@ -260,7 +260,6 @@ function parseEvents(route, driveEvents) {
 }
 
 export function fetchEvents(route) {
-  console.log('fetching events for route', route.fullname);
   return async (dispatch, getState) => {
     const state = getState();
     if (!state.routes) {
@@ -294,7 +293,6 @@ export function fetchEvents(route) {
     if (!USE_LOCAL_EVENTS_DATA) {
       // in cache?
       const cacheEvents = await getCacheItem('events', route.fullname, route.maxqlog);
-      console.log('cacheEvents', cacheEvents);
       if (cacheEvents !== null) {
         dispatch({
           type: Types.ACTION_UPDATE_ROUTE_EVENTS,

--- a/src/components/Timeline/index.jsx
+++ b/src/components/Timeline/index.jsx
@@ -65,7 +65,7 @@ const styles = () => ({
         background: theme.palette.states.alertRed,
       },
     },
-    '&.bookmark': {
+    '&.bookmark, &.flag': {  // TODO: remove flag selector once 14 days expires old events caches
       background: theme.palette.states.userBookmark,
       zIndex: 1,
     },


### PR DESCRIPTION
Connect caches the parsed events, not raw events, with the old flag event type. Fix for https://github.com/commaai/connect/pull/563