### PR TITLE
sign in: fix keyboard accessibility for all buttons

### DIFF
--- a/src/components/anonymous.jsx
+++ b/src/components/anonymous.jsx
@@ -79,6 +79,10 @@ const styles = () => ({
     '&:hover': {
       background: '#eee',
     },
+    '&:focus-visible': {
+      outline: '2px solid #fff',
+      outlineOffset: 2,
+    },
   },
   buttonText: {
     fontSize: 18,
@@ -148,7 +152,7 @@ class AnonymousLanding extends Component {
             <img className={classes.buttonImage} src={AuthGoogleIcon} alt="" />
             <Typography className={classes.buttonText}>Sign in with Google</Typography>
           </a>
-          <a onClick={() => AppleID.auth.signIn()} className={classes.logInButton}>
+          <a href="#" role="button" onClick={(e) => { e.preventDefault(); AppleID.auth.signIn(); }} className={classes.logInButton}>
             <img className={classes.buttonImage} src={AuthAppleIcon} alt="" />
             <Typography className={classes.buttonText}>Sign in with Apple</Typography>
           </a>


### PR DESCRIPTION
## Summary
- Apple sign-in button used `<a onClick>` without `href`, making it unreachable via Tab key — added `href="#"` + `role="button"` + `preventDefault`
- Added `focus-visible` outline styling to all sign-in buttons so keyboard users can see which one is focused
- Google and GitHub buttons already used `href` and were unaffected

## Note on the "Try the demo" button (#551)
The demo button is also `<a onClick>` without `href`, but it's rendered with `style={{ height: 0, overflow: 'hidden', opacity: 0 }}` — i.e. invisible. Making it keyboard-focusable would create a hidden tab stop, which is worse than the current state. The visibility itself looks like a separate bug (or dead code) and is left for a follow-up.

Partially addresses #551 (Apple button + focus styling). Demo button needs separate investigation.