### PR TITLE
fix: timeline selections starting at offset 0

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -172,7 +172,7 @@ function updateTimeline(state, dispatch, log_id, start, end, allowPathChange) {
   }
 
   if (allowPathChange) {
-    const wholeRoute = !Number.isFinite(start) || !Number.isFinite(end) || (start === 0 && end === route?.duration);
+    const wholeRoute = start == null || (start === 0 && end === route?.duration);
     const urlStart = wholeRoute ? null : Math.floor(start / 1000);
     const urlEnd = wholeRoute ? null : Math.floor(end / 1000);
     const desiredPath = urlForState(state.dongleId, log_id, urlStart, urlEnd, false);
@@ -197,6 +197,8 @@ export function popTimelineRange(log_id, allowPathChange = true) {
 }
 
 export function pushTimelineRange(log_id, start, end, allowPathChange = true) {
+  if (!Number.isFinite(start)) start = null;
+  if (!Number.isFinite(end)) end = null;
   return (dispatch, getState) => {
     const state = getState();
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -148,7 +148,7 @@ export function urlForState(dongleId, log_id, start, end, prime) {
 
   if (log_id) {
     path.push(log_id);
-    if (start && end && start > 0) {
+    if (Number.isFinite(start) && Number.isFinite(end) && start !== end) {
       path.push(start);
       path.push(end);
     }
@@ -160,10 +160,16 @@ export function urlForState(dongleId, log_id, start, end, prime) {
 }
 
 function updateTimeline(state, dispatch, log_id, start, end, allowPathChange) {
-  if (!state.loop || !state.loop.startTime || !state.loop.duration || state.loop.startTime < start
-    || state.loop.startTime + state.loop.duration > end || state.loop.duration < end - start) {
+  // null/null = "loop the full route" (URL stays /dongleId/log_id so a refresh
+  // on a still-uploading route picks up the latest duration).
+  const loopStart = Number.isFinite(start) ? start : 0;
+  const loopEnd = Number.isFinite(end) ? end : state.routes?.find((r) => r.log_id === log_id)?.duration;
+
+  if (Number.isFinite(loopEnd) && (!state.loop || !state.loop.duration
+    || state.loop.startTime < loopStart || state.loop.startTime + state.loop.duration > loopEnd
+    || state.loop.duration < loopEnd - loopStart)) {
     dispatch(resetPlayback());
-    dispatch(selectLoop(start, end));
+    dispatch(selectLoop(loopStart, loopEnd));
   }
 
   if (allowPathChange) {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -148,7 +148,7 @@ export function urlForState(dongleId, log_id, start, end, prime) {
 
   if (log_id) {
     path.push(log_id);
-    if (Number.isFinite(start) && Number.isFinite(end) && start !== end) {
+    if (start != null && end != null && start !== end) {
       path.push(start);
       path.push(end);
     }
@@ -160,12 +160,10 @@ export function urlForState(dongleId, log_id, start, end, prime) {
 }
 
 function updateTimeline(state, dispatch, log_id, start, end, allowPathChange) {
-  // null/null = "loop the full route" (URL stays /dongleId/log_id so a refresh
-  // on a still-uploading route picks up the latest duration).
-  const loopStart = Number.isFinite(start) ? start : 0;
-  const loopEnd = Number.isFinite(end) ? end : state.routes?.find((r) => r.log_id === log_id)?.duration;
+  const loopStart = start ?? 0;
+  const loopEnd = end ?? state.routes?.find((r) => r.log_id === log_id)?.duration;
 
-  if (Number.isFinite(loopEnd) && (!state.loop || !state.loop.duration
+  if (loopEnd != null && (!state.loop || !state.loop.duration
     || state.loop.startTime < loopStart || state.loop.startTime + state.loop.duration > loopEnd
     || state.loop.duration < loopEnd - loopStart)) {
     dispatch(resetPlayback());

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -160,8 +160,9 @@ export function urlForState(dongleId, log_id, start, end, prime) {
 }
 
 function updateTimeline(state, dispatch, log_id, start, end, allowPathChange) {
+  const route = state.routes?.find((r) => r.log_id === log_id);
   const loopStart = start ?? 0;
-  const loopEnd = end ?? state.routes?.find((r) => r.log_id === log_id)?.duration;
+  const loopEnd = end ?? route?.duration;
 
   if (loopEnd != null && (!state.loop || !state.loop.duration
     || state.loop.startTime < loopStart || state.loop.startTime + state.loop.duration > loopEnd
@@ -171,7 +172,10 @@ function updateTimeline(state, dispatch, log_id, start, end, allowPathChange) {
   }
 
   if (allowPathChange) {
-    const desiredPath = urlForState(state.dongleId, log_id, Math.floor(start/1000), Math.floor(end/1000), false);
+    const wholeRoute = !Number.isFinite(start) || !Number.isFinite(end) || (start === 0 && end === route?.duration);
+    const urlStart = wholeRoute ? null : Math.floor(start / 1000);
+    const urlEnd = wholeRoute ? null : Math.floor(end / 1000);
+    const desiredPath = urlForState(state.dongleId, log_id, urlStart, urlEnd, false);
     if (window.location.pathname !== desiredPath) {
       dispatch(push(desiredPath));
     }

--- a/src/actions/index.test.js
+++ b/src/actions/index.test.js
@@ -23,6 +23,6 @@ describe('timeline actions', () => {
       zoom: {},
     }));
     actionThunk(dispatch, getState);
-    expect(push).toBeCalledWith('/statedongle/log_id');
+    expect(push).toBeCalledWith('/statedongle/log_id/0/1');
   });
 });

--- a/src/components/Dashboard/DriveListItem.jsx
+++ b/src/components/Dashboard/DriveListItem.jsx
@@ -84,7 +84,7 @@ const DriveListItem = (props) => {
   }, [drive, dispatch, isVisible, el]);
 
   const onClick = filterRegularClick(
-    () => dispatch(pushTimelineRange(drive.log_id, 0, drive.duration, true)),
+    () => dispatch(pushTimelineRange(drive.log_id, null, null, true)),
   );
 
   const small = windowWidth < 580;

--- a/src/reducers/globalState.js
+++ b/src/reducers/globalState.js
@@ -289,7 +289,7 @@ export default function reducer(_state, action) {
       }
       break;
     case Types.TIMELINE_PUSH_SELECTION: {
-      if (!state.zoom || !action.start || !action.end || action.start < state.zoom.start || action.end > state.zoom.end) {
+      if (!state.zoom || action.start == null || action.end == null || action.start < state.zoom.start || action.end > state.zoom.end) {
         state.files = null;
       }
 
@@ -300,7 +300,7 @@ export default function reducer(_state, action) {
       const r = state.routes?.find((route) => route.log_id === action.log_id);
       if (action.log_id && r) {
         state.currentRoute = r;
-        if (!action.start) {
+        if (action.start == null) {
           state.zoom = {
             start: 0,
             end: state.currentRoute.duration,


### PR DESCRIPTION
## Summary

Dragging a section on the timeline ruler from the very start (offset 0) was silently broken — the selection wouldn't render and any pre-existing loop would be cleared. Two falsy-zero bugs both rooted in treating \`0\` as \"no value\":

- \`TIMELINE_PUSH_SELECTION\` reducer used \`!action.start\` to mean \"no selection,\" which is also true when the user drags from second 0. That branch reset zoom to the full route and cleared the loop instead of creating the section.
- \`urlForState\` dropped \`start\`/\`end\` from the URL when \`start === 0\` (\`start && end && start > 0\`), so even if the reducer had stored the right zoom, the URL forgot it on refresh.

Both replaced with explicit null checks. Updated the unit test that was asserting the buggy URL.

## Test plan

- [ ] Drag from second 0 on the route timeline → section renders, URL contains \`/0/N\`
- [ ] Drag from second 5 → unchanged behavior
- [ ] Refresh on \`/dongleId/log_id/0/N\` → loads the section
- [ ] \`pnpm lint\` clean
- [ ] \`pnpm test\` passes (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)