### PR TITLE
fix: clamp timeline drag selection to 1s minimum

### DIFF
--- a/src/components/Timeline/index.jsx
+++ b/src/components/Timeline/index.jsx
@@ -251,8 +251,14 @@ class Timeline extends Component {
     const rulerBounds = this.rulerRef.current.getBoundingClientRect();
     const startPercent = (Math.min(dragging[0], dragging[1]) - rulerBounds.x) / rulerBounds.width;
     const endPercent = (Math.max(dragging[0], dragging[1]) - rulerBounds.x) / rulerBounds.width;
-    const startOffset = Math.round(this.percentToOffset(startPercent));
-    const endOffset = Math.round(this.percentToOffset(endPercent));
+    // Round to whole seconds (URL precision) so the section bounds match what we
+    // serialize, and so any drag is at least 1s wide. No separate sub-second
+    // internal state to keep in sync.
+    const startOffset = Math.round(this.percentToOffset(startPercent) / 1000) * 1000;
+    let endOffset = Math.round(this.percentToOffset(endPercent) / 1000) * 1000;
+    if (endOffset <= startOffset) {
+      endOffset = startOffset + 1000;
+    }
 
     if (Math.abs(dragging[1] - dragging[0]) > 3) {
       const offset = currentOffset();


### PR DESCRIPTION
## Summary

Sub-second drag selections produced inconsistent state — zoom/loop held millisecond-precision bounds while the URL collapsed (\`Math.floor(start/1000) === Math.floor(end/1000)\`) and dropped the range. Reload would lose the section even though Redux still had it.

Round the drag's start/end to whole seconds (matching URL precision) and ensure end > start, so any drag becomes at least a 1-second section. No separate ms-precision internal state to keep in sync with the URL.

## Test plan

- [ ] Tiny drag (under a second) → resulting section is exactly 1s wide and reflected in the URL
- [ ] Normal drag (e.g. 5s span) → unchanged, still rounds to whole seconds
- [ ] Drag at second 0 → still creates a section (unrelated, but worth eyeballing alongside #592)
- [ ] \`pnpm lint\` clean
- [ ] \`pnpm test\` passes (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)