### PR TITLE
fix: re-fetch route list after closing direct-link route view

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -31,9 +31,13 @@ export function checkRoutesData() {
     console.debug('We need to update the segment metadata...');
     const { dongleId } = state;
     const fetchRange = state.filter;
+    // Direct visits to /dongleId/log_id fetch only that one route for speed.
+    // Remember that so we don't claim to have covered the full filter range —
+    // otherwise hasRoutesData lies and the dashboard never re-fetches when the
+    // user clicks X to close the route view.
+    const isSegmentFetch = !!state.segmentRange;
 
-    // if requested segment range not in loaded routes, fetch it explicitly
-    if (state.segmentRange) {
+    if (isSegmentFetch) {
       routesRequest = {
         req: Drives.getRoutesSegments(dongleId, undefined, undefined, undefined, `${dongleId}|${state.segmentRange.log_id}`),
         dongleId,
@@ -95,8 +99,11 @@ export function checkRoutesData() {
       dispatch({
         type: Types.ACTION_ROUTES_METADATA,
         dongleId,
-        start: fetchRange.start,
-        end: fetchRange.end,
+        // null start/end means "we did not cover the full filter range" so the
+        // next checkRoutesData (e.g. when the user closes back to the dashboard)
+        // will refetch all routes for the active filter.
+        start: isSegmentFetch ? null : fetchRange.start,
+        end: isSegmentFetch ? null : fetchRange.end,
         routes,
       });
 

--- a/src/components/Dashboard/DriveList.jsx
+++ b/src/components/Dashboard/DriveList.jsx
@@ -66,7 +66,7 @@ const DriveList = (props) => {
 
   return (
     <div className={classes.drivesTable}>
-      <VisibilityHandler onVisible={() => dispatch(checkRoutesData())} minInterval={60} />
+      <VisibilityHandler onInit onVisible={() => dispatch(checkRoutesData())} minInterval={60} />
       {content}
       {contentStatus}
     </div>


### PR DESCRIPTION
## Summary

When you visit \`/dongleId/log_id\` directly (no back history) and then click X to close, the dashboard shows only that one route until you refresh.

\`checkRoutesData\` takes a fast path when \`state.segmentRange\` is set, fetching only the targeted route. But it then dispatched \`ACTION_ROUTES_METADATA\` with \`start\`/\`end\` equal to the full filter range, so \`hasRoutesData\` returned true on the next check. \`DriveList\`'s visibility hook saw cached metadata and didn't refetch.

Pass \`null\` start/end when the fetch was segment-scoped. \`hasRoutesData\` then returns false, and the next \`checkRoutesData\` (fired by \`DriveList\` becoming visible after close) fills in the full filter range.

## Test plan

- [ ] Open \`/dongleId/log_id\` directly in a fresh tab → only that route loads (existing fast-path behavior preserved)
- [ ] Click X → dashboard shows the full route list, no refresh needed
- [ ] Open \`/dongleId\` directly → list loads normally, opening any route still works
- [ ] \`pnpm lint\` clean
- [ ] \`pnpm test\` passes (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)