### PR TITLE
mobile: preserve dashboard scroll on back; allow iOS edge-swipe

### DIFF
--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, useEffect } from 'react';
 import { connect } from 'react-redux';
 import Obstruction from 'obstruction';
 
@@ -18,7 +18,29 @@ const DashboardLoading = () => (
   </Grid>
 );
 
+// Persist the dashboard's scroll position across navigation so closing a route
+// returns the user to where they were. Stored in sessionStorage keyed by
+// dongleId so different devices don't stomp each other.
+const useDashboardScrollRestore = (dongleId) => {
+  useEffect(() => {
+    if (!dongleId) return undefined;
+    const key = `dashboard-scroll-${dongleId}`;
+
+    const saved = sessionStorage.getItem(key);
+    if (saved !== null) {
+      // Defer to next frame so children have a chance to lay out before we scroll.
+      requestAnimationFrame(() => window.scrollTo(0, parseInt(saved, 10)));
+    }
+
+    const onScroll = () => sessionStorage.setItem(key, String(window.scrollY));
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [dongleId]);
+};
+
 const Dashboard = ({ primeNav, device, dongleId }) => {
+  useDashboardScrollRestore(primeNav ? null : dongleId);
+
   if (!device || !dongleId) {
     return <DashboardLoading />;
   }

--- a/src/components/utils/PullDownReload.jsx
+++ b/src/components/utils/PullDownReload.jsx
@@ -60,6 +60,14 @@ class PullDownReload extends Component {
       return;
     }
 
+    // Don't capture touches that start near the screen edges — those are
+    // iOS' system back-swipe gestures and we shouldn't preventDefault on them.
+    const x = ev.touches[0].pageX;
+    const edgeWidth = 30;
+    if (x < edgeWidth || x > window.innerWidth - edgeWidth) {
+      return;
+    }
+
     this.setState({ startY: ev.touches[0].pageY });
   }
 


### PR DESCRIPTION
## Summary

Two related mobile UX fixes.

**1. Dashboard scroll restoration.** Closing a route view via X (or browser/OS back) jumped the dashboard to the top, losing the user's place in the list. Dashboard now persists \`window.scrollY\` to \`sessionStorage\` keyed by \`dongleId\` and restores on remount via \`requestAnimationFrame\` so children have a chance to lay out first.

**2. iOS edge-swipe-back.** \`PullDownReload\` registers \`touchstart\` with \`{ passive: false }\` at the document level. That swallowed iOS' system back-swipe gesture (which begins at the screen edge), so the gesture didn't work in the PWA. Skip touches that start within 30px of either screen edge so the OS gesture is preserved while pull-to-reload still works in the middle of the screen.

## Test plan

- [ ] iOS PWA: scroll down on dashboard, click a route, click X → dashboard returns to scrolled position
- [ ] iOS PWA: same flow but using the browser/OS back button
- [ ] iOS PWA: edge-swipe from left edge to go back works again
- [ ] Pull down from middle of screen still triggers reload
- [ ] Desktop / non-iOS: behavior unchanged
- [ ] \`pnpm lint\` clean
- [ ] \`pnpm test\` passes (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)