### PR TITLE
add secondary failure catch

### DIFF
--- a/src/components/BodyTeleop/Video.jsx
+++ b/src/components/BodyTeleop/Video.jsx
@@ -2,18 +2,20 @@ import React, { useState, useEffect } from 'react';
 import { Button } from '@material-ui/core';
 import Refresh from '@material-ui/icons/Refresh';
 
+import { ConnectStep } from '../../utils/webrtc';
 
-const progressLabels = {
-  20: 'Gathering direct connection candidates...',
-  40: 'Device processing candidates...',
-  85: 'Candidate accepted...',
-  92: 'Establishing connection...',
-  97: 'Receiving video...',
+const stepInfo = {
+  [ConnectStep.GATHERING_CANDIDATES]: { percent: 20, label: 'Gathering direct connection candidates...' },
+  [ConnectStep.PROCESSING_CANDIDATES]: { percent: 40, label: 'Device processing candidates...' },
+  [ConnectStep.CANDIDATE_ACCEPTED]: { percent: 85, label: 'Candidate accepted...' },
+  [ConnectStep.ESTABLISHING]: { percent: 92, label: 'Establishing connection...' },
+  [ConnectStep.RECEIVING_VIDEO]: { percent: 97, label: 'Receiving video...' },
 };
 
-const ConnectOverlay = ({ connectionState, error, connectProgress, onConnect }) => {
+const ConnectOverlay = ({ connectionState, error, connectStep, onConnect }) => {
   const connecting = connectionState === 'connecting';
   const canRetry = connectionState === 'failed' || connectionState === 'disconnected';
+  const { percent = 0, label = 'Connecting...' } = stepInfo[connectStep] || {};
 
   return (
     <div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
@@ -23,10 +25,10 @@ const ConnectOverlay = ({ connectionState, error, connectProgress, onConnect }) 
             <div className="w-60 h-1 rounded bg-white/10 overflow-hidden">
               <div
                 className="h-full rounded bg-white/70 transition-[width] duration-400 ease-in-out"
-                style={{ width: `${connectProgress || 0}%` }}
+                style={{ width: `${percent}%` }}
               />
             </div>
-            <span className="text-xs text-white/50">{progressLabels[connectProgress] || 'Connecting...'}</span>
+            <span className="text-xs text-white/50">{label}</span>
           </>
         ) : canRetry ? (
           <Button
@@ -50,7 +52,7 @@ const ConnectOverlay = ({ connectionState, error, connectProgress, onConnect }) 
 
 const Video = ({
   videoRef, connectionState, error,
-  connectProgress, onConnect, className
+  connectStep, onConnect, className
 }) => {
   const connected = connectionState === 'connected';
   const [playing, setPlaying] = useState(false);
@@ -75,7 +77,7 @@ const Video = ({
         <ConnectOverlay
           connectionState={connectionState}
           error={error}
-          connectProgress={connectProgress}
+          connectStep={connectStep}
           onConnect={onConnect}
         />
       )}

--- a/src/components/BodyTeleop/index.jsx
+++ b/src/components/BodyTeleop/index.jsx
@@ -12,8 +12,8 @@ import Video from './Video';
 import Joystick from './Joystick';
 
 const BodyTeleop = ({ dongleId, device, onClose }) => {
-  const [connectionState, setConnectionState] = useState('disconnected');
-  const [connectProgress, setConnectProgress] = useState(0);
+  const [connectionState, setConnectionState] = useState('none');
+  const [connectStep, setConnectStep] = useState(null);
   const [battery, setBattery] = useState(null);
   const [error, setError] = useState(null);
   const [isLandscape, setIsLandscape] = useState(false);
@@ -39,13 +39,13 @@ const BodyTeleop = ({ dongleId, device, onClose }) => {
       onConnectionState: (state, reason) => {
         setConnectionState(state);
         if (state !== 'connecting') {
-          setConnectProgress(0);
+          setConnectStep(null);
         }
         if (state === 'failed') {
           setError((prev) => prev || reason || 'Could not reach device. Is the ignition on?');
         }
       },
-      onConnectProgress: setConnectProgress,
+      onConnectProgress: setConnectStep,
       onBatteryLevel: setBattery,
       onConnectionReplaced: (data) => {
         setError(data || 'Connection replaced');
@@ -146,7 +146,7 @@ const BodyTeleop = ({ dongleId, device, onClose }) => {
 
   const videoProps = {
     videoRef, connectionState, error,
-    connectProgress,
+    connectStep,
     onConnect: handleConnect,
   };
 

--- a/src/utils/webrtc.js
+++ b/src/utils/webrtc.js
@@ -8,6 +8,13 @@ const CLOCK_WINDOW_SIZE = 16;
 const CLOCK_PING_MS = 500;
 
 const ICE_GATHER_DEADLINE_MS = 5000;
+const CONNECTION_DEADLINE_MS = 7000;
+
+export const ConnectStep = {
+  GATHERING_CANDIDATES: 1,
+  PROCESSING_CANDIDATES: 2,
+  ESTABLISHING: 3,
+};
 
 // Browsers obfuscate the local host behind a "<uuid>.local" mDNS hostname for
 // privacy. Aiortc can't resolve those https://github.com/commaai/connect/issues/609
@@ -32,6 +39,7 @@ export class WebRTCConnection {
     this.dc = null;
     this.joystickInterval = null;
     this.clockSyncInterval = null;
+    this.connectionTimeout = null;
     this.joystickX = 0;
     this.joystickY = 0;
     this.callbacks = callbacks;
@@ -88,11 +96,16 @@ export class WebRTCConnection {
         }
       });
 
+      this.connectionTimeout = setTimeout(() => {
+        this.cleanup();
+        this.callbacks.onConnectionState('failed');
+      }, CONNECTION_DEADLINE_MS);
+
       this.pc.addEventListener('connectionstatechange', () => {
         if (!this.pc) return;
         const state = this.pc.connectionState;
         if (state === 'connected') {
-          this.callbacks.onConnectProgress?.(97);
+          this._clearConnectionTimeout();
           this.callbacks.onConnectionState('connected');
         }
       });
@@ -125,7 +138,7 @@ export class WebRTCConnection {
 
       const offer = await this.pc.createOffer();
       await this.pc.setLocalDescription(offer);
-      this.callbacks.onConnectProgress?.(20);
+      this.callbacks.onConnectProgress?.(ConnectStep.GATHERING_CANDIDATES);
 
       const pc = this.pc;
 
@@ -133,6 +146,8 @@ export class WebRTCConnection {
       const gatheringComplete = new Promise((resolve) => { resolveComplete = resolve; });
       pc.addEventListener('icecandidate', (evt) => {
         if (!evt.candidate) { resolveComplete(); }
+        // host candidates are normally faster than srlfx and relay so will already be available
+        else if (evt.candidate.type == 'srflx' || evt.candidate.type === 'relay') { resolveComplete(); }
       });
 
       await Promise.race([gatheringComplete, asyncSleep(ICE_GATHER_DEADLINE_MS)]);
@@ -145,7 +160,7 @@ export class WebRTCConnection {
           "If error persists, your network may not allow direct peer-to-peer connections."
         );
       }
-      this.callbacks.onConnectProgress?.(40);
+      this.callbacks.onConnectProgress?.(ConnectStep.PROCESSING_CANDIDATES);
 
       const resp = await Athena.postJsonRpcPayload(dongleId, {
         method: 'startStream',
@@ -161,9 +176,8 @@ export class WebRTCConnection {
         throw new Error('Could not reach device. Is the ignition on?');
       }
       
-      this.callbacks.onConnectProgress?.(85);
+      this.callbacks.onConnectProgress?.(ConnectStep.ESTABLISHING);
       await this.pc.setRemoteDescription({ type: 'answer', sdp: resp.result.sdp });
-      this.callbacks.onConnectProgress?.(92);
     } catch (err) {
       this.cleanup();
       this.callbacks.onConnectionState('failed');
@@ -185,6 +199,13 @@ export class WebRTCConnection {
 
   setQuality(quality) {
     this._sendDc('livestreamSettings', { quality: quality });
+  }
+
+  _clearConnectionTimeout() {
+    if (this.connectionTimeout) {
+      clearTimeout(this.connectionTimeout);
+      this.connectionTimeout = null;
+    }
   }
 
   _clearJoystickInterval() {
@@ -274,6 +295,7 @@ export class WebRTCConnection {
   }
 
   cleanup() {
+    this._clearConnectionTimeout();
     this._clearJoystickInterval();
     this._stopClockSync();
     if (this.dc) {

--- a/src/utils/webrtc.js
+++ b/src/utils/webrtc.js
@@ -146,7 +146,8 @@ export class WebRTCConnection {
       const gatheringComplete = new Promise((resolve) => { resolveComplete = resolve; });
       pc.addEventListener('icecandidate', (evt) => {
         if (!evt.candidate) { resolveComplete(); }
-        // host candidates are normally faster than srlfx and relay so will already be available
+        // Chrome sends null candidate after connectionstate is compelete making promise finish after sleep timeout
+        // Host candidates are faster than srlfx and relay so will already be available
         else if (evt.candidate.type == 'srflx' || evt.candidate.type === 'relay') { resolveComplete(); }
       });
 


### PR DESCRIPTION
- add timeout on no "connected" event, which implies that all ICE candidates found on browser side were rejected and no other ICE candidates were found.
- create progress enums
- fast exit option from gather step if `srflx` or `relay option is found
  - until trickle ice is implemented this significantly speeds up connection, especially on Chrome since Chrome implementation of 'icegatheringstatechange' only sends completed event once the connection has already been formed.