### PR TITLE
fix: re-enable Try the demo button

### DIFF
--- a/src/components/anonymous.jsx
+++ b/src/components/anonymous.jsx
@@ -163,8 +163,7 @@ class AnonymousLanding extends Component {
           </span>
 
           <a onClick={loginAsDemoUser}
-            className="flex items-center pl-4 pr-3 py-2 font-medium border border-white rounded-full hover:bg-[rgba(255,255,255,0.1)] active:bg-[rgba(255,255,255,0.2)] transition-colors"
-            style={{ height: 0, overflow: 'hidden', opacity: 0 }}
+            className="flex items-center pl-4 pr-3 py-2 font-medium border border-white rounded-full hover:bg-[rgba(255,255,255,0.1)] active:bg-[rgba(255,255,255,0.2)] transition-colors cursor-pointer"
           >
             Try the demo
             <RightArrow className="ml-1 h-4" />


### PR DESCRIPTION
## Summary

The "Try the demo" button was hidden in #578 (`disable demo for now`). The likely
root cause was the JWT token expiring repeatedly, requiring manual rotation.

The token was subsequently updated with a far-future expiry in commit `da834ce`
("one more time"), eliminating the need for manual rotation going forward.

The demo account is active and the experience works end-to-end: login, dashboard,
drive list, and map view all function correctly — useful for contributors without
a comma device, as mentioned in the README.

PR #586 noted this as a "separate bug, left for follow-up."