### PR TITLE
fix: device name change doesn't update immediately

### DIFF
--- a/src/reducers/globalState.js
+++ b/src/reducers/globalState.js
@@ -134,6 +134,9 @@ export default function reducer(_state, action) {
       } else {
         state.devices.unshift(populateFetchedAt(action.device));
       }
+      if (state.dongleId && action.device.dongle_id === state.dongleId) {
+        state.device = populateFetchedAt(action.device);
+      }
       break;
     case Types.ACTION_UPDATE_ROUTE:
       if (state.routes) {

--- a/src/reducers/globalState.js
+++ b/src/reducers/globalState.js
@@ -134,6 +134,7 @@ export default function reducer(_state, action) {
       } else {
         state.devices.unshift(populateFetchedAt(action.device));
       }
+      // force ui update on renaming
       if (state.dongleId && action.device.dongle_id === state.dongleId) {
         state.device = populateFetchedAt(action.device);
       }


### PR DESCRIPTION
Fixes #641.

`ACTION_UPDATE_DEVICE` updated `state.devices[]` but not `state.device`, so
`DeviceInfo`/`CommacareBadge` (which read `state.device`) kept showing the old
name until a reload. Same fix `ACTION_UPDATE_DEVICES` already does, just for
the single-device case.