### PR TITLE
prime(fix): free trial checkout for nodata plan

### DIFF
--- a/src/components/Prime/PrimeCheckout.jsx
+++ b/src/components/Prime/PrimeCheckout.jsx
@@ -277,9 +277,10 @@ class PrimeCheckout extends Component {
     this.setState({ loadingCheckout: true });
     try {
       const { selectedPlan: plan } = this.state;
+      const simId = plan === 'nodata' ? subscribeInfo.sim_id : undefined;
       const resp = await Billing.getStripeCheckout(
         dongleId,
-        subscribeInfo.sim_id,
+        simId,
         plan,
       );
       dispatch(analyticsEvent('prime_checkout', { plan }));


### PR DESCRIPTION
free trial claim for nodata plan fails if there is an existing sim id for the device that is not 19/20 digits because it was adding sim id unconditionally.

remove the sim id for prime lite, since it is not necessary for activation 