### PR TITLE
prime: fetch subscription on nav

### DIFF
--- a/src/components/Prime/PrimeCheckout.jsx
+++ b/src/components/Prime/PrimeCheckout.jsx
@@ -12,7 +12,7 @@ import { billing as Billing } from '@commaai/api';
 import { deviceNamePretty } from '../../utils';
 import ResizeHandler from '../ResizeHandler';
 import Colors from '../../colors';
-import { primeNav, analyticsEvent } from '../../actions';
+import { primeNav, analyticsEvent, primeFetchSubscription } from '../../actions';
 import { ErrorOutline, InfoOutline } from '../../icons';
 import CommacareIcon from '../../icons/commacare.png';
 import { COMMACARE_URL } from '../CommacareBadge';
@@ -253,6 +253,10 @@ class PrimeCheckout extends Component {
   }
 
   componentDidMount() {
+    const { dispatch, dongleId, device } = this.props;
+    if (dongleId) {
+      dispatch(primeFetchSubscription(dongleId, device));
+    }
     this.componentDidUpdate({});
   }
 

--- a/src/components/Prime/PrimeCheckout.jsx
+++ b/src/components/Prime/PrimeCheckout.jsx
@@ -281,7 +281,7 @@ class PrimeCheckout extends Component {
     this.setState({ loadingCheckout: true });
     try {
       const { selectedPlan: plan } = this.state;
-      const simId = plan === 'nodata' ? subscribeInfo.sim_id : undefined;
+      const simId = plan === 'data' ? subscribeInfo.sim_id : undefined;
       const resp = await Billing.getStripeCheckout(
         dongleId,
         simId,


### PR DESCRIPTION
connect was stuck in "fetching sim data..." because it was getting the subscription status when the device was clicked in the sidebar not on load of /prime

