### PR TITLE
fix: drive view scrolled down

### DIFF
--- a/src/components/DriveView/index.jsx
+++ b/src/components/DriveView/index.jsx
@@ -18,6 +18,10 @@ class DriveView extends Component {
     this.close = this.close.bind(this);
   }
 
+  componentDidMount() {
+    window.scrollTo({ top: 0 });
+  }
+
   onBack(zoom, currentRoute) {
     if (zoom.previous) {
       this.props.dispatch(popTimelineRange(currentRoute?.log_id));

--- a/src/components/DriveView/index.jsx
+++ b/src/components/DriveView/index.jsx
@@ -18,10 +18,6 @@ class DriveView extends Component {
     this.close = this.close.bind(this);
   }
 
-  componentDidMount() {
-    window.scrollTo({ top: 0 });
-  }
-
   onBack(zoom, currentRoute) {
     if (zoom.previous) {
       this.props.dispatch(popTimelineRange(currentRoute?.log_id));

--- a/src/components/explorer.jsx
+++ b/src/components/explorer.jsx
@@ -194,9 +194,7 @@ class ExplorerApp extends Component {
     const headerHeight = this.state.headerRef
       ? this.state.headerRef.getBoundingClientRect().height
       : (windowWidth < 640 ? 111 : 66);
-    let containerStyles = {
-      minHeight: `calc(100vh - ${headerHeight}px)`,
-    };
+    let containerStyles = {};
     if (isLarge) {
       containerStyles = {
         ...containerStyles,

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,7 @@
 
 :root {
   color-scheme: dark;
+  background: #16181A;
 }
 
 html {


### PR DESCRIPTION
sometimes the drive view would open scrolled down

fixed by removing the extra height of the div which didn't need to exist. Now its not scrollable.

if we add more stuff in the future, scroll can be reset to 0 on load