### PR TITLE
Replace MUI AppBar with React and Tailwind

### DIFF
--- a/src/components/AppHeader/index.jsx
+++ b/src/components/AppHeader/index.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Obstruction from 'obstruction';
 
 import { withStyles } from '@material-ui/core/styles';
-import { Typography, IconButton, AppBar } from '@material-ui/core';
+import { Typography, IconButton } from '@material-ui/core';
 import MenuIcon from '@material-ui/icons/Menu';
 
 import MyCommaAuth from '@commaai/my-comma-auth';
@@ -15,6 +15,7 @@ import { filterRegularClick } from '../../utils';
 
 import AccountMenu from './AccountMenu';
 import PWAIcon from '../PWAIcon';
+import AppBar from '../ui/AppBar';
 
 const styles = () => ({
   header: {

--- a/src/components/ui/AppBar.jsx
+++ b/src/components/ui/AppBar.jsx
@@ -1,0 +1,25 @@
+import React, { forwardRef } from 'react';
+
+const positions = {
+  absolute: 'absolute',
+  fixed: 'fixed',
+  relative: 'relative',
+  static: 'static',
+  sticky: 'sticky top-0',
+};
+
+const AppBar = forwardRef(({
+  children, className = '', elevation = 0, position = 'fixed', ...props
+}, ref) => (
+  <header
+    ref={ref}
+    className={`${positions[position] || positions.fixed} z-[1100] w-full bg-[#30373b] text-white ${elevation ? 'shadow-md' : ''} ${className}`}
+    {...props}
+  >
+    {children}
+  </header>
+));
+
+AppBar.displayName = 'AppBar';
+
+export default AppBar;


### PR DESCRIPTION
Replaces the MUI AppBar core component with a small native React header styled with Tailwind.\n\nThis is PR 1 of 23 in the stacked MUI core-component removal series.\n\nVerification: `bun run lint`, `bun run build:production`, and `bun run test --runInBand`.