### PR TITLE
Preserve route after login

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ import FullPageLoading from './components/FullPageLoading';
 const Explorer = lazy(() => import('./components/explorer'));
 const AnonymousLanding = lazy(() => import('./components/anonymous'));
 
-class App extends Component {
+export class App extends Component {
   constructor(props) {
     super(props);
 
@@ -87,12 +87,17 @@ class App extends Component {
   }
 
   redirectLink() {
+    if (this.redirectURL !== undefined) {
+      return this.redirectURL;
+    }
+
     let url = '/';
     if (typeof window.sessionStorage !== 'undefined' && sessionStorage.getItem('redirectURL') !== null) {
       url = sessionStorage.getItem('redirectURL');
       sessionStorage.removeItem('redirectURL');
     }
-    return url;
+    this.redirectURL = url;
+    return this.redirectURL;
   }
 
   authRoutes() {

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,11 +1,21 @@
 /* eslint-env jest */
 import { act, render } from '@testing-library/react';
-import App from '../App';
+import App, { App as AppComponent } from '../App';
 
 describe('App', () => {
   it('should not crash', () => {
     act(() => {
       render(<App />);
     });
+  });
+
+  it('preserves the login redirect across renders', () => {
+    const route = '/0123456789abcdef/00000000--0123456789/0/60';
+    window.sessionStorage.setItem('redirectURL', route);
+    const app = new AppComponent({});
+
+    expect(app.redirectLink()).toBe(route);
+    expect(window.sessionStorage.getItem('redirectURL')).toBeNull();
+    expect(app.redirectLink()).toBe(route);
   });
 });


### PR DESCRIPTION
Fix the post-login redirect so a route link remains stable across React renders.

`redirectLink()` previously consumed `sessionStorage.redirectURL` during render. If the auth route rendered again before `<Redirect>` completed navigation, the second call fell back to `/` and sent the user to the home page. Cache the consumed value on the App instance so every render in the same login flow uses the original route.

The regression test calls `redirectLink()` twice and verifies both calls return the route while the session-storage value is still consumed once.

Tested:
- Login redirect regression test
- 28 non-network Jest tests
- `oxlint src`
- Production Vite build

The existing live geocoding integration test timed out against its external service locally.

Fixes #702
