### PR TITLE
Stabilize device online status

### DIFF
--- a/src/actions/devicePresence.test.js
+++ b/src/actions/devicePresence.test.js
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+import { athena as Athena } from '../api';
+import { fetchDeviceNetworkStatus } from './index';
+import * as Types from './types';
+
+const DONGLE_ID = '0123456789abcdef';
+
+function getState(version = '0.8.14') {
+  return {
+    device: {
+      dongle_id: DONGLE_ID,
+      openpilot_version: version,
+    },
+    devices: [],
+  };
+}
+
+describe('device presence', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not update presence after a successful auxiliary RPC', async () => {
+    jest.spyOn(Athena, 'postJsonRpcPayload').mockResolvedValue({ result: true });
+    const dispatch = jest.fn();
+
+    await fetchDeviceNetworkStatus(DONGLE_ID)(dispatch, () => getState());
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: Types.ACTION_UPDATE_DEVICE_NETWORK,
+      dongleId: DONGLE_ID,
+      networkMetered: true,
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mark the device offline when an auxiliary RPC times out', async () => {
+    jest.spyOn(Athena, 'postJsonRpcPayload').mockRejectedValue(new Error('Timed out'));
+    const dispatch = jest.fn();
+
+    await fetchDeviceNetworkStatus(DONGLE_ID)(dispatch, () => getState());
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/actions/files.js
+++ b/src/actions/files.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react';
 import { athena as Athena, devices as Devices, raw as Raw } from '../api';
 
-import { updateDeviceOnline, fetchDeviceNetworkStatus } from '.';
+import { fetchDeviceNetworkStatus } from '.';
 import * as Types from './types';
 import { deviceOnCellular, getDeviceFromState, deviceVersionAtLeast, asyncSleep } from '../utils';
 
@@ -154,13 +154,9 @@ export function fetchUploadQueue(dongleId) {
     };
     const uploadQueue = await athenaCall(dongleId, payload, 'action_files_athena_uploadqueue');
     if (!uploadQueue || !uploadQueue.result) {
-      if (uploadQueue && uploadQueue.offline) {
-        dispatch(updateDeviceOnline(dongleId, 0));
-      }
       cancelFetchUploadQueue();
       return;
     }
-    dispatch(updateDeviceOnline(dongleId, Math.floor(Date.now() / 1000)));
 
     const prevFilesUploading = getState().filesUploading || {};
     const device = getDeviceFromState(getState(), dongleId);
@@ -238,10 +234,7 @@ export function doUpload(dongleId, paths, urls) {
           state[pathToFileName(dongleId, path)] = {};
           return state;
         }, {});
-        dispatch(updateDeviceOnline(dongleId, Math.floor(Date.now() / 1000)));
         dispatch(updateFiles(newUploading));
-      } else if (resp.offline) {
-        dispatch(updateDeviceOnline(dongleId, 0));
       } else if (resp.result === 'Device offline, message queued') {
         const newUploading = paths.reduce((state, path) => {
           state[pathToFileName(dongleId, path)] = { progress: 0, current: false };
@@ -288,10 +281,7 @@ export function doUpload(dongleId, paths, urls) {
         if (!resp || resp.error) {
           const uploading = {};
           uploading[pathToFileName(dongleId, paths[i])] = {};
-          dispatch(updateDeviceOnline(dongleId, Math.floor(Date.now() / 1000)));
           dispatch(updateFiles(uploading));
-        } else if (resp.offline) {
-          dispatch(updateDeviceOnline(dongleId, 0));
         } else if (resp.result === 'Device offline, message queued') {
           const uploading = {};
           uploading[pathToFileName(dongleId, paths[i])] = { progress: 0, current: false };
@@ -355,8 +345,6 @@ export function cancelUploads(dongleId, ids) {
         dongleId,
         ids: idsArray,
       });
-    } else if (resp && resp.offline) {
-      dispatch(updateDeviceOnline(dongleId, 0));
     }
   };
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -377,17 +377,6 @@ export function fetchSharedDevice(dongleId) {
   };
 }
 
-export function updateDeviceOnline(dongleId, lastAthenaPing) {
-  return (dispatch) => {
-    dispatch({
-      type: Types.ACTION_UPDATE_DEVICE_ONLINE,
-      dongleId,
-      last_athena_ping: lastAthenaPing,
-      fetched_at: Math.floor(Date.now() / 1000),
-    });
-  };
-}
-
 export function fetchDeviceNetworkStatus(dongleId) {
   return async (dispatch, getState) => {
     const device = getDeviceFromState(getState(), dongleId);
@@ -405,12 +394,9 @@ export function fetchDeviceNetworkStatus(dongleId) {
             dongleId,
             networkMetered: resp.result,
           });
-          dispatch(updateDeviceOnline(dongleId, Math.floor(Date.now() / 1000)));
         }
       } catch (err) {
-        if (err.message && (err.message.indexOf('Timed out') === -1 || err.message.indexOf('Device not registered') === -1)) {
-          dispatch(updateDeviceOnline(dongleId, 0));
-        } else {
+        if (!err.message || (err.message.indexOf('Timed out') === -1 && err.message.indexOf('Device not registered') === -1)) {
           console.error(err);
           Sentry.captureException(err, { fingerprint: 'athena_fetch_networkmetered' });
         }
@@ -430,12 +416,9 @@ export function fetchDeviceNetworkStatus(dongleId) {
             dongleId,
             networkMetered: metered,
           });
-          dispatch(updateDeviceOnline(dongleId, Math.floor(Date.now() / 1000)));
         }
       } catch (err) {
-        if (err.message && (err.message.indexOf('Timed out') === -1 || err.message.indexOf('Device not registered') === -1)) {
-          dispatch(updateDeviceOnline(dongleId, 0));
-        } else {
+        if (!err.message || (err.message.indexOf('Timed out') === -1 && err.message.indexOf('Device not registered') === -1)) {
           console.error(err);
           Sentry.captureException(err, { fingerprint: 'athena_fetch_networktype' });
         }


### PR DESCRIPTION
Stop auxiliary Athena RPCs from overwriting device presence.

Device API refreshes already provide the authoritative `last_athena_ping`. Network-status and upload RPCs were also setting it to either the current time or zero, so out-of-order responses could make a reachable device flicker online and offline.

Keep the upload and network-state updates unchanged, but remove their presence writes. `fetchDeviceOnline()` remains the sole action-level writer and continues to use `Devices.fetchDevice()`.

Also fix the network probe's expected-error condition: timeout and unregistered-device errors are ignored, while unexpected errors are still reported.

Tested:
- New success and timeout presence-race tests
- 29 non-network Jest tests
- `oxlint src`
- Production Vite build

The existing live geocoding integration test depends on an external service and timed out locally.

Fixes #687
