### PR TITLE
expose demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Try it with your openpilot device:
 * Install bun: https://bun.sh/docs/installation
 * Install dependencies: `bun install`
 * Start dev server: `bun start`
-* Open dev server with demo account: `bun start:demo`
+* Demo mode: Navigate to `/demo` to test locally without a comma device.
 
 API and useradmin URL roots can be overridden at build time with
 `VITE_COMMA_URL_ROOT`, `VITE_ATHENA_URL_ROOT`, `VITE_BILLING_URL_ROOT`, and

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Try it with your openpilot device:
 * Install bun: https://bun.sh/docs/installation
 * Install dependencies: `bun install`
 * Start dev server: `bun start`
+* Open dev server with demo account: `bun start:demo`
 
 API and useradmin URL roots can be overridden at build time with
 `VITE_COMMA_URL_ROOT`, `VITE_ATHENA_URL_ROOT`, `VITE_BILLING_URL_ROOT`, and

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.8.0",
   "scripts": {
     "start": "vite",
-    "start:demo": "vite --open /demo",
     "build:development": "vite build --mode development",
     "build:production": "vite build",
     "build:gallery": "bun add --no-save --trust puppeteer@24.16.0 pixelmatch@7.1.0 pngjs@7.0.0 && node scripts/build-gallery.mjs",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.0",
   "scripts": {
     "start": "vite",
+    "start:demo": "vite --open /demo",
     "build:development": "vite build --mode development",
     "build:production": "vite build",
     "build:gallery": "bun add --no-save --trust puppeteer@24.16.0 pixelmatch@7.1.0 pngjs@7.0.0 && node scripts/build-gallery.mjs",


### PR DESCRIPTION
Alternatively, we could avoid adding a new script and simply update the README to suggest navigating to `/demo` after running `bun start`.